### PR TITLE
Multi python build

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -299,6 +299,8 @@ jobs:
     strategy:
       matrix:
         py_version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        exclude:
+          - py_version: "3.8"
 
     steps:
     - uses: actions/checkout@v2
@@ -397,6 +399,8 @@ jobs:
     strategy:
       matrix:
         py_version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        exclude:
+          - py_version: "3.8"
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -222,6 +222,8 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: "${{ matrix.py_version }}"
+        exclude:
+          - py_version: "3.6"
 
     - name: Install pip dependencies
       run: |

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -214,6 +214,8 @@ jobs:
     strategy:
       matrix:
         py_version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        exclude:
+          - py_version: "3.8"
 
     steps:
     - uses: actions/checkout@v2
@@ -222,8 +224,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: "${{ matrix.py_version }}"
-        exclude:
-          - py_version: "3.6"
 
     - name: Install pip dependencies
       run: |

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -17,6 +17,9 @@ jobs:
     # You can convert this to a matrix build if you need cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        py_version: [3.6, 3.7, 3.8, 3.9, 3.10]
 
     steps:
     - uses: actions/checkout@v2
@@ -28,12 +31,13 @@ jobs:
     
     - name: Install platform specific requirements
       run: |
-        sudo apt-get install -y flex bison python3-dev python3 libfl-dev
+        sudo apt-get install -y flex bison 
+      # python3-dev python3 libfl-dev
       
-    - name: Set up Python 3.10
+    - name: Set up Python ${{ matrix.py_version }}
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "${{ matrix.py_version }}"
 
     - name: Print GLIBC version
       run: ldd --version
@@ -78,10 +82,15 @@ jobs:
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: ctest
 
+    - uses: jungwinter/split@v2
+        id: split
+        with:
+          msg: ${{ matrix.py_version }}
+
     - name: Build Pypi Python Package
       run: |
         cd ${{github.workspace}}/${{env.BUILD_TYPE}}/_package
-        python3 setup.py bdist_wheel --plat-name=manylinux_2_31_x86_64
+        python3 setup.py bdist_wheel --python-tag=cp${{ steps.split.outputs._0 }}${{ steps.split.outputs._1 }} --plat-name=manylinux_2_31_x86_64
 
     - name: Pytest
       working-directory: ${{github.workspace}}
@@ -95,334 +104,334 @@ jobs:
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
-# --------------------------------------------------------------------------- #
+# # --------------------------------------------------------------------------- #
 
-  build-ubuntu-18:
-    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
-    # You can convert this to a matrix build if you need cross-platform coverage.
-    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: ubuntu-18.04
+#   build-ubuntu-18:
+#     # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
+#     # You can convert this to a matrix build if you need cross-platform coverage.
+#     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+#     runs-on: ubuntu-18.04
 
-    steps:
-    - uses: actions/checkout@v2
+#     steps:
+#     - uses: actions/checkout@v2
 
-    - name: Remove previous builds if any
-      run: | 
-        rm -rf ${{github.workspace}}/build
-        rm -rf ${{github.workspace}}/${{env.BUILD_TYPE}}
+#     - name: Remove previous builds if any
+#       run: | 
+#         rm -rf ${{github.workspace}}/build
+#         rm -rf ${{github.workspace}}/${{env.BUILD_TYPE}}
     
-    - name: Install platform specific requirements
-      run: |
-        sudo apt-get install -y flex bison python3-dev python3 libfl-dev
+#     - name: Install platform specific requirements
+#       run: |
+#         sudo apt-get install -y flex bison python3-dev python3 libfl-dev
       
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v2
-      with:
-        python-version: "3.10"
+#     - name: Set up Python 3.10
+#       uses: actions/setup-python@v2
+#       with:
+#         python-version: "3.10"
 
-    - name: Print GLIBC version
-      run: ldd --version
+#     - name: Print GLIBC version
+#       run: ldd --version
 
-    - name: Install pip dependencies
-      run: |
-        python3 -m pip install --upgrade pip
-        python3 -m pip install flake8 pytest
-        python3 -m pip install --upgrade build wheel twine
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+#     - name: Install pip dependencies
+#       run: |
+#         python3 -m pip install --upgrade pip
+#         python3 -m pip install flake8 pytest
+#         python3 -m pip install --upgrade build wheel twine
+#         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
-    - name: Configure CMake
-      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      # Notes- 
-      # 1. Doxygen fails on Ubuntu 18- Requires glibc 2.29
-      run: > 
-        cmake -B ${{github.workspace}}/build 
-        -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
-        -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/${{env.BUILD_TYPE}}
-        -DUSE_SUPERBUILD=ON
-        -DCMAKE_FF_CXX=ON
-        -DCMAKE_LEGACY_PLANNER=OFF
-        -DCMAKE_FD=ON
-        -DCMAKE_TARSKI=ON
-        -DCMAKE_DOXYGEN_DOCS=OFF 
-        -DCMAKE_DOXYGEN_FLAT_THEME=OFF
-        -DCMAKE_DOXYGEN_AWESOME_THEME=OFF
-        -DCMAKE_SPHINX_DOCS=OFF 
-        -DCMAKE_STATIC_BOOST=ON
-        -DCMAKE_TESTING_ENABLED=ON
+#     - name: Configure CMake
+#       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+#       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+#       # Notes- 
+#       # 1. Doxygen fails on Ubuntu 18- Requires glibc 2.29
+#       run: > 
+#         cmake -B ${{github.workspace}}/build 
+#         -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+#         -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/${{env.BUILD_TYPE}}
+#         -DUSE_SUPERBUILD=ON
+#         -DCMAKE_FF_CXX=ON
+#         -DCMAKE_LEGACY_PLANNER=OFF
+#         -DCMAKE_FD=ON
+#         -DCMAKE_TARSKI=ON
+#         -DCMAKE_DOXYGEN_DOCS=OFF 
+#         -DCMAKE_DOXYGEN_FLAT_THEME=OFF
+#         -DCMAKE_DOXYGEN_AWESOME_THEME=OFF
+#         -DCMAKE_SPHINX_DOCS=OFF 
+#         -DCMAKE_STATIC_BOOST=ON
+#         -DCMAKE_TESTING_ENABLED=ON
 
-    - name: Build
-      # Build your program with the given configuration
-      run: > 
-        cmake --build ${{github.workspace}}/build
+#     - name: Build
+#       # Build your program with the given configuration
+#       run: > 
+#         cmake --build ${{github.workspace}}/build
 
-    - name: Install Python Package
-      run: python3 -m pip install ${{github.workspace}}/${{env.BUILD_TYPE}}/_package
+#     - name: Install Python Package
+#       run: python3 -m pip install ${{github.workspace}}/${{env.BUILD_TYPE}}/_package
 
-    - name: CTest
-      working-directory: ${{github.workspace}}/build
-      # Execute tests defined by the CMake configuration.  
-      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest
+#     - name: CTest
+#       working-directory: ${{github.workspace}}/build
+#       # Execute tests defined by the CMake configuration.  
+#       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+#       run: ctest
 
-    - name: Build Pypi Python Package
-      run: |
-        cd ${{github.workspace}}/${{env.BUILD_TYPE}}/_package
-        python3 setup.py bdist_wheel --plat-name=manylinux_2_27_x86_64
+#     - name: Build Pypi Python Package
+#       run: |
+#         cd ${{github.workspace}}/${{env.BUILD_TYPE}}/_package
+#         python3 setup.py bdist_wheel --plat-name=manylinux_2_27_x86_64
 
-    - name: Pytest
-      working-directory: ${{github.workspace}}
-      run: |
-        pytest
+#     - name: Pytest
+#       working-directory: ${{github.workspace}}
+#       run: |
+#         pytest
         
-    - name: Lint with flake8
-      run: |
-        # DON'T[ANU: To be changed later] stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --exit-zero --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+#     - name: Lint with flake8
+#       run: |
+#         # DON'T[ANU: To be changed later] stop the build if there are Python syntax errors or undefined names
+#         flake8 . --count --exit-zero --select=E9,F63,F7,F82 --show-source --statistics
+#         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+#         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
-# --------------------------------------------------------------------------- #
+# # --------------------------------------------------------------------------- #
 
-  build-windows-2019:
-    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
-    # You can convert this to a matrix build if you need cross-platform coverage.
-    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: windows-2019
+#   build-windows-2019:
+#     # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
+#     # You can convert this to a matrix build if you need cross-platform coverage.
+#     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+#     runs-on: windows-2019
 
-    steps:
-    - uses: actions/checkout@v2
+#     steps:
+#     - uses: actions/checkout@v2
       
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v2
-      with:
-        python-version: "3.10"
+#     - name: Set up Python 3.10
+#       uses: actions/setup-python@v2
+#       with:
+#         python-version: "3.10"
 
-    - name: Install pip dependencies
-      run: |
-        py -m pip install --upgrade pip
-        py -m pip install flake8 pytest
-        py -m pip install --upgrade build wheel twine
+#     - name: Install pip dependencies
+#       run: |
+#         py -m pip install --upgrade pip
+#         py -m pip install flake8 pytest
+#         py -m pip install --upgrade build wheel twine
 
-    - name: Configure CMake
-      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: > 
-        cmake -B ${{github.workspace}}/build 
-        -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
-        -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/${{env.BUILD_TYPE}}
-        -DCMAKE_GENERATOR="MinGW Makefiles"
-        -DUSE_SUPERBUILD=ON
-        -DCMAKE_FF_CXX=OFF
-        -DCMAKE_LEGACY_PLANNER=OFF
-        -DCMAKE_FD=ON
-        -DCMAKE_TARSKI=ON
-        -DCMAKE_DOXYGEN_DOCS=OFF
-        -DCMAKE_DOXYGEN_FLAT_THEME=OFF
-        -DCMAKE_DOXYGEN_AWESOME_THEME=OFF
-        -DCMAKE_SPHINX_DOCS=OFF
-        -DCMAKE_STATIC_BOOST=ON
-        -DCMAKE_TESTING_ENABLED=ON
+#     - name: Configure CMake
+#       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+#       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+#       run: > 
+#         cmake -B ${{github.workspace}}/build 
+#         -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+#         -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/${{env.BUILD_TYPE}}
+#         -DCMAKE_GENERATOR="MinGW Makefiles"
+#         -DUSE_SUPERBUILD=ON
+#         -DCMAKE_FF_CXX=OFF
+#         -DCMAKE_LEGACY_PLANNER=OFF
+#         -DCMAKE_FD=ON
+#         -DCMAKE_TARSKI=ON
+#         -DCMAKE_DOXYGEN_DOCS=OFF
+#         -DCMAKE_DOXYGEN_FLAT_THEME=OFF
+#         -DCMAKE_DOXYGEN_AWESOME_THEME=OFF
+#         -DCMAKE_SPHINX_DOCS=OFF
+#         -DCMAKE_STATIC_BOOST=ON
+#         -DCMAKE_TESTING_ENABLED=ON
 
-    - name: Build
-      # Build your program with the given configuration
-      run: > 
-        cmake --build ${{github.workspace}}/build
+#     - name: Build
+#       # Build your program with the given configuration
+#       run: > 
+#         cmake --build ${{github.workspace}}/build
 
-    - name: Install Python Package
-      run: py -m pip install ${{github.workspace}}/${{env.BUILD_TYPE}}/_package
+#     - name: Install Python Package
+#       run: py -m pip install ${{github.workspace}}/${{env.BUILD_TYPE}}/_package
 
-    - name: CTest
-      working-directory: ${{github.workspace}}/build
-      # Execute tests defined by the CMake configuration.  
-      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest
+#     - name: CTest
+#       working-directory: ${{github.workspace}}/build
+#       # Execute tests defined by the CMake configuration.  
+#       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+#       run: ctest
 
-    - name: Build Pypi Python Package
-      run: |
-        cd ${{github.workspace}}/${{env.BUILD_TYPE}}/_package
-        py setup.py bdist_wheel --plat-name=win_amd64
+#     - name: Build Pypi Python Package
+#       run: |
+#         cd ${{github.workspace}}/${{env.BUILD_TYPE}}/_package
+#         py setup.py bdist_wheel --plat-name=win_amd64
 
-    - name: Pytest
-      working-directory: ${{github.workspace}}
-      run: |
-        pytest
+#     - name: Pytest
+#       working-directory: ${{github.workspace}}
+#       run: |
+#         pytest
 
-    - name: Lint with flake8
-      run: |
-        # DON'T[ANU: To be changed later] stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --exit-zero --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+#     - name: Lint with flake8
+#       run: |
+#         # DON'T[ANU: To be changed later] stop the build if there are Python syntax errors or undefined names
+#         flake8 . --count --exit-zero --select=E9,F63,F7,F82 --show-source --statistics
+#         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+#         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
-# --------------------------------------------------------------------------- #
+# # --------------------------------------------------------------------------- #
 
-  build-macos-latest:
-    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
-    # You can convert this to a matrix build if you need cross-platform coverage.
-    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: macos-latest
+#   build-macos-latest:
+#     # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
+#     # You can convert this to a matrix build if you need cross-platform coverage.
+#     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+#     runs-on: macos-latest
 
-    steps:
-    - uses: actions/checkout@v2
+#     steps:
+#     - uses: actions/checkout@v2
 
-    - name: Remove previous builds if any
-      run: | 
-        rm -rf ${{github.workspace}}/build
-        rm -rf ${{github.workspace}}/${{env.BUILD_TYPE}}
+#     - name: Remove previous builds if any
+#       run: | 
+#         rm -rf ${{github.workspace}}/build
+#         rm -rf ${{github.workspace}}/${{env.BUILD_TYPE}}
 
-    - name: Install platform specific dependencies
-      run: |
-        brew install flex bison python3 libffi
+#     - name: Install platform specific dependencies
+#       run: |
+#         brew install flex bison python3 libffi
 
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v2
-      with:
-        python-version: "3.10"
+#     - name: Set up Python 3.10
+#       uses: actions/setup-python@v2
+#       with:
+#         python-version: "3.10"
 
-    - name: Install pip dependencies
-      run: |
-        python3 -m pip install --upgrade pip
-        python3 -m pip install flake8 pytest
-        python3 -m pip install --upgrade build wheel twine
-        brew install gcc@10
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+#     - name: Install pip dependencies
+#       run: |
+#         python3 -m pip install --upgrade pip
+#         python3 -m pip install flake8 pytest
+#         python3 -m pip install --upgrade build wheel twine
+#         brew install gcc@10
+#         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
-    - name: Configure CMake
-      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: > 
-        cmake -B ${{github.workspace}}/build 
-        -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
-        -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/${{env.BUILD_TYPE}}
-        -DCMAKE_GENERATOR="Unix Makefiles"
-        -DCMAKE_C_COMPILER=gcc-10
-        -DCMAKE_CXX_COMPILER=g++-10
-        -DUSE_SUPERBUILD=ON
-        -DCMAKE_FF_CXX=OFF
-        -DCMAKE_LEGACY_PLANNER=OFF
-        -DCMAKE_FD=ON
-        -DCMAKE_TARSKI=ON
-        -DCMAKE_DOXYGEN_DOCS=OFF
-        -DCMAKE_DOXYGEN_FLAT_THEME=OFF
-        -DCMAKE_DOXYGEN_AWESOME_THEME=OFF
-        -DCMAKE_SPHINX_DOCS=OFF
-        -DCMAKE_STATIC_BOOST=ON
-        -DCMAKE_TESTING_ENABLED=ON
+#     - name: Configure CMake
+#       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+#       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+#       run: > 
+#         cmake -B ${{github.workspace}}/build 
+#         -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+#         -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/${{env.BUILD_TYPE}}
+#         -DCMAKE_GENERATOR="Unix Makefiles"
+#         -DCMAKE_C_COMPILER=gcc-10
+#         -DCMAKE_CXX_COMPILER=g++-10
+#         -DUSE_SUPERBUILD=ON
+#         -DCMAKE_FF_CXX=OFF
+#         -DCMAKE_LEGACY_PLANNER=OFF
+#         -DCMAKE_FD=ON
+#         -DCMAKE_TARSKI=ON
+#         -DCMAKE_DOXYGEN_DOCS=OFF
+#         -DCMAKE_DOXYGEN_FLAT_THEME=OFF
+#         -DCMAKE_DOXYGEN_AWESOME_THEME=OFF
+#         -DCMAKE_SPHINX_DOCS=OFF
+#         -DCMAKE_STATIC_BOOST=ON
+#         -DCMAKE_TESTING_ENABLED=ON
 
-    - name: Build
-      # Build your program with the given configuration
-      run: > 
-        cmake --build ${{github.workspace}}/build
+#     - name: Build
+#       # Build your program with the given configuration
+#       run: > 
+#         cmake --build ${{github.workspace}}/build
 
-    - name: Install Python Package
-      run: python3 -m pip install ${{github.workspace}}/${{env.BUILD_TYPE}}/_package
+#     - name: Install Python Package
+#       run: python3 -m pip install ${{github.workspace}}/${{env.BUILD_TYPE}}/_package
 
-    # - name: CTest
-    #   working-directory: ${{github.workspace}}/build
-    #   # Execute tests defined by the CMake configuration.  
-    #   # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-    #   run: ctest
+#     # - name: CTest
+#     #   working-directory: ${{github.workspace}}/build
+#     #   # Execute tests defined by the CMake configuration.  
+#     #   # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+#     #   run: ctest
 
-    - name: Build Pypi Python Package
-      run: |
-        cd ${{github.workspace}}/${{env.BUILD_TYPE}}/_package
-        python3 setup.py bdist_wheel --plat-name=macosx_11_0_x86_64
+#     - name: Build Pypi Python Package
+#       run: |
+#         cd ${{github.workspace}}/${{env.BUILD_TYPE}}/_package
+#         python3 setup.py bdist_wheel --plat-name=macosx_11_0_x86_64
 
-    - name: Pytest
-      working-directory: ${{github.workspace}}
-      run: |
-        pytest
+#     - name: Pytest
+#       working-directory: ${{github.workspace}}
+#       run: |
+#         pytest
 
-    - name: Lint with flake8
-      run: |
-        # DON'T[ANU: To be changed later] stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --exit-zero --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+#     - name: Lint with flake8
+#       run: |
+#         # DON'T[ANU: To be changed later] stop the build if there are Python syntax errors or undefined names
+#         flake8 . --count --exit-zero --select=E9,F63,F7,F82 --show-source --statistics
+#         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+#         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
-# --------------------------------------------------------------------------- #
+# # --------------------------------------------------------------------------- #
         
-  build-macos-10_15:
-    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
-    # You can convert this to a matrix build if you need cross-platform coverage.
-    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: macos-10.15
+#   build-macos-10_15:
+#     # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
+#     # You can convert this to a matrix build if you need cross-platform coverage.
+#     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+#     runs-on: macos-10.15
 
-    steps:
-    - uses: actions/checkout@v2
+#     steps:
+#     - uses: actions/checkout@v2
 
-    - name: Remove previous builds if any
-      run: | 
-        rm -rf ${{github.workspace}}/build
-        rm -rf ${{github.workspace}}/${{env.BUILD_TYPE}}
+#     - name: Remove previous builds if any
+#       run: | 
+#         rm -rf ${{github.workspace}}/build
+#         rm -rf ${{github.workspace}}/${{env.BUILD_TYPE}}
 
-    - name: Install platform specific dependencies
-      run: |
-        brew install flex bison python3 libffi
+#     - name: Install platform specific dependencies
+#       run: |
+#         brew install flex bison python3 libffi
 
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v2
-      with:
-        python-version: "3.10"
+#     - name: Set up Python 3.10
+#       uses: actions/setup-python@v2
+#       with:
+#         python-version: "3.10"
 
-    - name: Install dependencies
-      run: |
-        python3 -m pip install --upgrade pip
-        python3 -m pip install flake8 pytest
-        python3 -m pip install --upgrade build wheel twine
-        brew install gcc@10
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+#     - name: Install dependencies
+#       run: |
+#         python3 -m pip install --upgrade pip
+#         python3 -m pip install flake8 pytest
+#         python3 -m pip install --upgrade build wheel twine
+#         brew install gcc@10
+#         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
-    - name: Configure CMake
-      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: > 
-        cmake -B ${{github.workspace}}/build 
-        -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
-        -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/${{env.BUILD_TYPE}}
-        -DCMAKE_GENERATOR="Unix Makefiles"
-        -DCMAKE_C_COMPILER=gcc-10
-        -DCMAKE_CXX_COMPILER=g++-10
-        -DUSE_SUPERBUILD=ON
-        -DCMAKE_FF_CXX=OFF
-        -DCMAKE_LEGACY_PLANNER=OFF
-        -DCMAKE_FD=ON
-        -DCMAKE_TARSKI=ON
-        -DCMAKE_DOXYGEN_DOCS=OFF
-        -DCMAKE_DOXYGEN_FLAT_THEME=OFF
-        -DCMAKE_DOXYGEN_AWESOME_THEME=OFF
-        -DCMAKE_SPHINX_DOCS=OFF
-        -DCMAKE_STATIC_BOOST=ON
-        -DCMAKE_TESTING_ENABLED=ON
+#     - name: Configure CMake
+#       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+#       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+#       run: > 
+#         cmake -B ${{github.workspace}}/build 
+#         -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+#         -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/${{env.BUILD_TYPE}}
+#         -DCMAKE_GENERATOR="Unix Makefiles"
+#         -DCMAKE_C_COMPILER=gcc-10
+#         -DCMAKE_CXX_COMPILER=g++-10
+#         -DUSE_SUPERBUILD=ON
+#         -DCMAKE_FF_CXX=OFF
+#         -DCMAKE_LEGACY_PLANNER=OFF
+#         -DCMAKE_FD=ON
+#         -DCMAKE_TARSKI=ON
+#         -DCMAKE_DOXYGEN_DOCS=OFF
+#         -DCMAKE_DOXYGEN_FLAT_THEME=OFF
+#         -DCMAKE_DOXYGEN_AWESOME_THEME=OFF
+#         -DCMAKE_SPHINX_DOCS=OFF
+#         -DCMAKE_STATIC_BOOST=ON
+#         -DCMAKE_TESTING_ENABLED=ON
 
-    - name: Build
-      # Build your program with the given configuration
-      run: > 
-        cmake --build ${{github.workspace}}/build
+#     - name: Build
+#       # Build your program with the given configuration
+#       run: > 
+#         cmake --build ${{github.workspace}}/build
 
-    - name: Install Python Package
-      run: python3 -m pip install ${{github.workspace}}/${{env.BUILD_TYPE}}/_package
+#     - name: Install Python Package
+#       run: python3 -m pip install ${{github.workspace}}/${{env.BUILD_TYPE}}/_package
 
-    - name: CTest
-      working-directory: ${{github.workspace}}/build
-      # Execute tests defined by the CMake configuration.  
-      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest
+#     - name: CTest
+#       working-directory: ${{github.workspace}}/build
+#       # Execute tests defined by the CMake configuration.  
+#       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+#       run: ctest
 
-    - name: Build Pypi Python Package
-      run: |
-        cd ${{github.workspace}}/${{env.BUILD_TYPE}}/_package
-        python3 setup.py bdist_wheel --plat-name=macosx_10_15_x86_64
+#     - name: Build Pypi Python Package
+#       run: |
+#         cd ${{github.workspace}}/${{env.BUILD_TYPE}}/_package
+#         python3 setup.py bdist_wheel --plat-name=macosx_10_15_x86_64
 
-    - name: Pytest
-      working-directory: ${{github.workspace}}
-      run: |
-        pytest
+#     - name: Pytest
+#       working-directory: ${{github.workspace}}
+#       run: |
+#         pytest
 
-    - name: Lint with flake8
-      run: |
-        # DON'T[ANU: To be changed later] stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --exit-zero --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+#     - name: Lint with flake8
+#       run: |
+#         # DON'T[ANU: To be changed later] stop the build if there are Python syntax errors or undefined names
+#         flake8 . --count --exit-zero --select=E9,F63,F7,F82 --show-source --statistics
+#         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+#         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -86,6 +86,7 @@ jobs:
       id: split
       with:
         msg: ${{ matrix.py_version }}
+        separator: '.'
 
     - name: Build Pypi Python Package
       run: |
@@ -104,334 +105,370 @@ jobs:
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
-# # --------------------------------------------------------------------------- #
+# --------------------------------------------------------------------------- #
 
-#   build-ubuntu-18:
-#     # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
-#     # You can convert this to a matrix build if you need cross-platform coverage.
-#     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-#     runs-on: ubuntu-18.04
+  build-ubuntu-18:
+    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
+    # You can convert this to a matrix build if you need cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        py_version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
 
-#     steps:
-#     - uses: actions/checkout@v2
+    steps:
+    - uses: actions/checkout@v2
 
-#     - name: Remove previous builds if any
-#       run: | 
-#         rm -rf ${{github.workspace}}/build
-#         rm -rf ${{github.workspace}}/${{env.BUILD_TYPE}}
+    - name: Remove previous builds if any
+      run: | 
+        rm -rf ${{github.workspace}}/build
+        rm -rf ${{github.workspace}}/${{env.BUILD_TYPE}}
     
-#     - name: Install platform specific requirements
-#       run: |
-#         sudo apt-get install -y flex bison python3-dev python3 libfl-dev
+    - name: Install platform specific requirements
+      run: |
+        sudo apt-get install -y flex bison python3-dev python3 libfl-dev
       
-#     - name: Set up Python 3.10
-#       uses: actions/setup-python@v2
-#       with:
-#         python-version: "3.10"
+    - name: Set up Python ${{ matrix.py_version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: "${{ matrix.py_version }}"
 
-#     - name: Print GLIBC version
-#       run: ldd --version
+    - name: Print GLIBC version
+      run: ldd --version
 
-#     - name: Install pip dependencies
-#       run: |
-#         python3 -m pip install --upgrade pip
-#         python3 -m pip install flake8 pytest
-#         python3 -m pip install --upgrade build wheel twine
-#         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Install pip dependencies
+      run: |
+        python3 -m pip install --upgrade pip
+        python3 -m pip install flake8 pytest
+        python3 -m pip install --upgrade build wheel twine
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
-#     - name: Configure CMake
-#       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-#       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-#       # Notes- 
-#       # 1. Doxygen fails on Ubuntu 18- Requires glibc 2.29
-#       run: > 
-#         cmake -B ${{github.workspace}}/build 
-#         -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
-#         -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/${{env.BUILD_TYPE}}
-#         -DUSE_SUPERBUILD=ON
-#         -DCMAKE_FF_CXX=ON
-#         -DCMAKE_LEGACY_PLANNER=OFF
-#         -DCMAKE_FD=ON
-#         -DCMAKE_TARSKI=ON
-#         -DCMAKE_DOXYGEN_DOCS=OFF 
-#         -DCMAKE_DOXYGEN_FLAT_THEME=OFF
-#         -DCMAKE_DOXYGEN_AWESOME_THEME=OFF
-#         -DCMAKE_SPHINX_DOCS=OFF 
-#         -DCMAKE_STATIC_BOOST=ON
-#         -DCMAKE_TESTING_ENABLED=ON
+    - name: Configure CMake
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      # Notes- 
+      # 1. Doxygen fails on Ubuntu 18- Requires glibc 2.29
+      run: > 
+        cmake -B ${{github.workspace}}/build 
+        -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+        -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/${{env.BUILD_TYPE}}
+        -DUSE_SUPERBUILD=ON
+        -DCMAKE_FF_CXX=ON
+        -DCMAKE_LEGACY_PLANNER=OFF
+        -DCMAKE_FD=ON
+        -DCMAKE_TARSKI=ON
+        -DCMAKE_DOXYGEN_DOCS=OFF 
+        -DCMAKE_DOXYGEN_FLAT_THEME=OFF
+        -DCMAKE_DOXYGEN_AWESOME_THEME=OFF
+        -DCMAKE_SPHINX_DOCS=OFF 
+        -DCMAKE_STATIC_BOOST=ON
+        -DCMAKE_TESTING_ENABLED=ON
 
-#     - name: Build
-#       # Build your program with the given configuration
-#       run: > 
-#         cmake --build ${{github.workspace}}/build
+    - name: Build
+      # Build your program with the given configuration
+      run: > 
+        cmake --build ${{github.workspace}}/build
 
-#     - name: Install Python Package
-#       run: python3 -m pip install ${{github.workspace}}/${{env.BUILD_TYPE}}/_package
+    - name: Install Python Package
+      run: python3 -m pip install ${{github.workspace}}/${{env.BUILD_TYPE}}/_package
 
-#     - name: CTest
-#       working-directory: ${{github.workspace}}/build
-#       # Execute tests defined by the CMake configuration.  
-#       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-#       run: ctest
+    - name: CTest
+      working-directory: ${{github.workspace}}/build
+      # Execute tests defined by the CMake configuration.  
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      run: ctest
 
-#     - name: Build Pypi Python Package
-#       run: |
-#         cd ${{github.workspace}}/${{env.BUILD_TYPE}}/_package
-#         python3 setup.py bdist_wheel --plat-name=manylinux_2_27_x86_64
+    - uses: jungwinter/split@v2
+      id: split
+      with:
+        msg: ${{ matrix.py_version }}
+        separator: '.'
 
-#     - name: Pytest
-#       working-directory: ${{github.workspace}}
-#       run: |
-#         pytest
+    - name: Build Pypi Python Package
+      run: |
+        cd ${{github.workspace}}/${{env.BUILD_TYPE}}/_package
+        python3 setup.py bdist_wheel --python-tag=cp${{ steps.split.outputs._0 }}${{ steps.split.outputs._1 }} --plat-name=manylinux_2_27_x86_64
+
+    - name: Pytest
+      working-directory: ${{github.workspace}}
+      run: |
+        pytest
         
-#     - name: Lint with flake8
-#       run: |
-#         # DON'T[ANU: To be changed later] stop the build if there are Python syntax errors or undefined names
-#         flake8 . --count --exit-zero --select=E9,F63,F7,F82 --show-source --statistics
-#         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-#         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Lint with flake8
+      run: |
+        # DON'T[ANU: To be changed later] stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --exit-zero --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
-# # --------------------------------------------------------------------------- #
+# --------------------------------------------------------------------------- #
 
-#   build-windows-2019:
-#     # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
-#     # You can convert this to a matrix build if you need cross-platform coverage.
-#     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-#     runs-on: windows-2019
+  build-windows-2019:
+    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
+    # You can convert this to a matrix build if you need cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    runs-on: windows-2019
+    strategy:
+      matrix:
+        py_version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
 
-#     steps:
-#     - uses: actions/checkout@v2
+    steps:
+    - uses: actions/checkout@v2
       
-#     - name: Set up Python 3.10
-#       uses: actions/setup-python@v2
-#       with:
-#         python-version: "3.10"
+    - name: Set up Python ${{ matrix.py_version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: "${{ matrix.py_version }}"
 
-#     - name: Install pip dependencies
-#       run: |
-#         py -m pip install --upgrade pip
-#         py -m pip install flake8 pytest
-#         py -m pip install --upgrade build wheel twine
+    - name: Install pip dependencies
+      run: |
+        py -m pip install --upgrade pip
+        py -m pip install flake8 pytest
+        py -m pip install --upgrade build wheel twine
 
-#     - name: Configure CMake
-#       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-#       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-#       run: > 
-#         cmake -B ${{github.workspace}}/build 
-#         -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
-#         -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/${{env.BUILD_TYPE}}
-#         -DCMAKE_GENERATOR="MinGW Makefiles"
-#         -DUSE_SUPERBUILD=ON
-#         -DCMAKE_FF_CXX=OFF
-#         -DCMAKE_LEGACY_PLANNER=OFF
-#         -DCMAKE_FD=ON
-#         -DCMAKE_TARSKI=ON
-#         -DCMAKE_DOXYGEN_DOCS=OFF
-#         -DCMAKE_DOXYGEN_FLAT_THEME=OFF
-#         -DCMAKE_DOXYGEN_AWESOME_THEME=OFF
-#         -DCMAKE_SPHINX_DOCS=OFF
-#         -DCMAKE_STATIC_BOOST=ON
-#         -DCMAKE_TESTING_ENABLED=ON
+    - name: Configure CMake
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: > 
+        cmake -B ${{github.workspace}}/build 
+        -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+        -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/${{env.BUILD_TYPE}}
+        -DCMAKE_GENERATOR="MinGW Makefiles"
+        -DUSE_SUPERBUILD=ON
+        -DCMAKE_FF_CXX=OFF
+        -DCMAKE_LEGACY_PLANNER=OFF
+        -DCMAKE_FD=ON
+        -DCMAKE_TARSKI=ON
+        -DCMAKE_DOXYGEN_DOCS=OFF
+        -DCMAKE_DOXYGEN_FLAT_THEME=OFF
+        -DCMAKE_DOXYGEN_AWESOME_THEME=OFF
+        -DCMAKE_SPHINX_DOCS=OFF
+        -DCMAKE_STATIC_BOOST=ON
+        -DCMAKE_TESTING_ENABLED=ON
 
-#     - name: Build
-#       # Build your program with the given configuration
-#       run: > 
-#         cmake --build ${{github.workspace}}/build
+    - name: Build
+      # Build your program with the given configuration
+      run: > 
+        cmake --build ${{github.workspace}}/build
 
-#     - name: Install Python Package
-#       run: py -m pip install ${{github.workspace}}/${{env.BUILD_TYPE}}/_package
+    - name: Install Python Package
+      run: py -m pip install ${{github.workspace}}/${{env.BUILD_TYPE}}/_package
 
-#     - name: CTest
-#       working-directory: ${{github.workspace}}/build
-#       # Execute tests defined by the CMake configuration.  
-#       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-#       run: ctest
+    - name: CTest
+      working-directory: ${{github.workspace}}/build
+      # Execute tests defined by the CMake configuration.  
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      run: ctest
 
-#     - name: Build Pypi Python Package
-#       run: |
-#         cd ${{github.workspace}}/${{env.BUILD_TYPE}}/_package
-#         py setup.py bdist_wheel --plat-name=win_amd64
+    - uses: jungwinter/split@v2
+      id: split
+      with:
+        msg: ${{ matrix.py_version }}
+        separator: '.'
 
-#     - name: Pytest
-#       working-directory: ${{github.workspace}}
-#       run: |
-#         pytest
+    - name: Build Pypi Python Package
+      run: |
+        cd ${{github.workspace}}/${{env.BUILD_TYPE}}/_package
+        py setup.py bdist_wheel --python-tag=cp${{ steps.split.outputs._0 }}${{ steps.split.outputs._1 }} --plat-name=win_amd64
 
-#     - name: Lint with flake8
-#       run: |
-#         # DON'T[ANU: To be changed later] stop the build if there are Python syntax errors or undefined names
-#         flake8 . --count --exit-zero --select=E9,F63,F7,F82 --show-source --statistics
-#         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-#         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Pytest
+      working-directory: ${{github.workspace}}
+      run: |
+        pytest
 
-# # --------------------------------------------------------------------------- #
+    - name: Lint with flake8
+      run: |
+        # DON'T[ANU: To be changed later] stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --exit-zero --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
-#   build-macos-latest:
-#     # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
-#     # You can convert this to a matrix build if you need cross-platform coverage.
-#     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-#     runs-on: macos-latest
+# --------------------------------------------------------------------------- #
 
-#     steps:
-#     - uses: actions/checkout@v2
+  build-macos-11:
+    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
+    # You can convert this to a matrix build if you need cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    runs-on: macos-11
+    strategy:
+      matrix:
+        py_version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
 
-#     - name: Remove previous builds if any
-#       run: | 
-#         rm -rf ${{github.workspace}}/build
-#         rm -rf ${{github.workspace}}/${{env.BUILD_TYPE}}
+    steps:
+    - uses: actions/checkout@v2
 
-#     - name: Install platform specific dependencies
-#       run: |
-#         brew install flex bison python3 libffi
+    - name: Remove previous builds if any
+      run: | 
+        rm -rf ${{github.workspace}}/build
+        rm -rf ${{github.workspace}}/${{env.BUILD_TYPE}}
 
-#     - name: Set up Python 3.10
-#       uses: actions/setup-python@v2
-#       with:
-#         python-version: "3.10"
+    - name: Install platform specific dependencies
+      run: |
+        brew install flex bison python3 libffi
 
-#     - name: Install pip dependencies
-#       run: |
-#         python3 -m pip install --upgrade pip
-#         python3 -m pip install flake8 pytest
-#         python3 -m pip install --upgrade build wheel twine
-#         brew install gcc@10
-#         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Set up Python ${{ matrix.py_version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: "${{ matrix.py_version }}"
 
-#     - name: Configure CMake
-#       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-#       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-#       run: > 
-#         cmake -B ${{github.workspace}}/build 
-#         -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
-#         -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/${{env.BUILD_TYPE}}
-#         -DCMAKE_GENERATOR="Unix Makefiles"
-#         -DCMAKE_C_COMPILER=gcc-10
-#         -DCMAKE_CXX_COMPILER=g++-10
-#         -DUSE_SUPERBUILD=ON
-#         -DCMAKE_FF_CXX=OFF
-#         -DCMAKE_LEGACY_PLANNER=OFF
-#         -DCMAKE_FD=ON
-#         -DCMAKE_TARSKI=ON
-#         -DCMAKE_DOXYGEN_DOCS=OFF
-#         -DCMAKE_DOXYGEN_FLAT_THEME=OFF
-#         -DCMAKE_DOXYGEN_AWESOME_THEME=OFF
-#         -DCMAKE_SPHINX_DOCS=OFF
-#         -DCMAKE_STATIC_BOOST=ON
-#         -DCMAKE_TESTING_ENABLED=ON
+    - name: Install pip dependencies
+      run: |
+        python3 -m pip install --upgrade pip
+        python3 -m pip install flake8 pytest
+        python3 -m pip install --upgrade build wheel twine
+        brew install gcc@10
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
-#     - name: Build
-#       # Build your program with the given configuration
-#       run: > 
-#         cmake --build ${{github.workspace}}/build
+    - name: Configure CMake
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: > 
+        cmake -B ${{github.workspace}}/build 
+        -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+        -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/${{env.BUILD_TYPE}}
+        -DCMAKE_GENERATOR="Unix Makefiles"
+        -DCMAKE_C_COMPILER=gcc-10
+        -DCMAKE_CXX_COMPILER=g++-10
+        -DUSE_SUPERBUILD=ON
+        -DCMAKE_FF_CXX=OFF
+        -DCMAKE_LEGACY_PLANNER=OFF
+        -DCMAKE_FD=ON
+        -DCMAKE_TARSKI=ON
+        -DCMAKE_DOXYGEN_DOCS=OFF
+        -DCMAKE_DOXYGEN_FLAT_THEME=OFF
+        -DCMAKE_DOXYGEN_AWESOME_THEME=OFF
+        -DCMAKE_SPHINX_DOCS=OFF
+        -DCMAKE_STATIC_BOOST=ON
+        -DCMAKE_TESTING_ENABLED=ON
 
-#     - name: Install Python Package
-#       run: python3 -m pip install ${{github.workspace}}/${{env.BUILD_TYPE}}/_package
+    - name: Build
+      # Build your program with the given configuration
+      run: > 
+        cmake --build ${{github.workspace}}/build
 
-#     # - name: CTest
-#     #   working-directory: ${{github.workspace}}/build
-#     #   # Execute tests defined by the CMake configuration.  
-#     #   # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-#     #   run: ctest
+    - name: Install Python Package
+      run: python3 -m pip install ${{github.workspace}}/${{env.BUILD_TYPE}}/_package
 
-#     - name: Build Pypi Python Package
-#       run: |
-#         cd ${{github.workspace}}/${{env.BUILD_TYPE}}/_package
-#         python3 setup.py bdist_wheel --plat-name=macosx_11_0_x86_64
+    - name: CTest
+      working-directory: ${{github.workspace}}/build
+      # Execute tests defined by the CMake configuration.  
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      run: ctest
 
-#     - name: Pytest
-#       working-directory: ${{github.workspace}}
-#       run: |
-#         pytest
+    - uses: jungwinter/split@v2
+      id: split
+      with:
+        msg: ${{ matrix.py_version }}
+        separator: '.'
 
-#     - name: Lint with flake8
-#       run: |
-#         # DON'T[ANU: To be changed later] stop the build if there are Python syntax errors or undefined names
-#         flake8 . --count --exit-zero --select=E9,F63,F7,F82 --show-source --statistics
-#         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-#         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Build Pypi Python Package
+      run: |
+        cd ${{github.workspace}}/${{env.BUILD_TYPE}}/_package
+        python3 setup.py bdist_wheel --python-tag=cp${{ steps.split.outputs._0 }}${{ steps.split.outputs._1 }} --plat-name=macosx_11_0_x86_64
 
-# # --------------------------------------------------------------------------- #
+    - name: Pytest
+      working-directory: ${{github.workspace}}
+      run: |
+        pytest
+
+    - name: Lint with flake8
+      run: |
+        # DON'T[ANU: To be changed later] stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --exit-zero --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
+# --------------------------------------------------------------------------- #
         
-#   build-macos-10_15:
-#     # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
-#     # You can convert this to a matrix build if you need cross-platform coverage.
-#     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-#     runs-on: macos-10.15
+  build-macos-10_15:
+    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
+    # You can convert this to a matrix build if you need cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    runs-on: macos-10.15
+    strategy:
+      matrix:
+        py_version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
 
-#     steps:
-#     - uses: actions/checkout@v2
+    steps:
+    - uses: actions/checkout@v2
 
-#     - name: Remove previous builds if any
-#       run: | 
-#         rm -rf ${{github.workspace}}/build
-#         rm -rf ${{github.workspace}}/${{env.BUILD_TYPE}}
+    - name: Remove previous builds if any
+      run: | 
+        rm -rf ${{github.workspace}}/build
+        rm -rf ${{github.workspace}}/${{env.BUILD_TYPE}}
 
-#     - name: Install platform specific dependencies
-#       run: |
-#         brew install flex bison python3 libffi
+    - name: Install platform specific dependencies
+      run: |
+        brew install flex bison python3 libffi
 
-#     - name: Set up Python 3.10
-#       uses: actions/setup-python@v2
-#       with:
-#         python-version: "3.10"
+    - name: Set up Python ${{ matrix.py_version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: "${{ matrix.py_version }}"
 
-#     - name: Install dependencies
-#       run: |
-#         python3 -m pip install --upgrade pip
-#         python3 -m pip install flake8 pytest
-#         python3 -m pip install --upgrade build wheel twine
-#         brew install gcc@10
-#         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Install dependencies
+      run: |
+        python3 -m pip install --upgrade pip
+        python3 -m pip install flake8 pytest
+        python3 -m pip install --upgrade build wheel twine
+        brew install gcc@10
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
-#     - name: Configure CMake
-#       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-#       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-#       run: > 
-#         cmake -B ${{github.workspace}}/build 
-#         -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
-#         -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/${{env.BUILD_TYPE}}
-#         -DCMAKE_GENERATOR="Unix Makefiles"
-#         -DCMAKE_C_COMPILER=gcc-10
-#         -DCMAKE_CXX_COMPILER=g++-10
-#         -DUSE_SUPERBUILD=ON
-#         -DCMAKE_FF_CXX=OFF
-#         -DCMAKE_LEGACY_PLANNER=OFF
-#         -DCMAKE_FD=ON
-#         -DCMAKE_TARSKI=ON
-#         -DCMAKE_DOXYGEN_DOCS=OFF
-#         -DCMAKE_DOXYGEN_FLAT_THEME=OFF
-#         -DCMAKE_DOXYGEN_AWESOME_THEME=OFF
-#         -DCMAKE_SPHINX_DOCS=OFF
-#         -DCMAKE_STATIC_BOOST=ON
-#         -DCMAKE_TESTING_ENABLED=ON
+    - name: Configure CMake
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: > 
+        cmake -B ${{github.workspace}}/build 
+        -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+        -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/${{env.BUILD_TYPE}}
+        -DCMAKE_GENERATOR="Unix Makefiles"
+        -DCMAKE_C_COMPILER=gcc-10
+        -DCMAKE_CXX_COMPILER=g++-10
+        -DUSE_SUPERBUILD=ON
+        -DCMAKE_FF_CXX=OFF
+        -DCMAKE_LEGACY_PLANNER=OFF
+        -DCMAKE_FD=ON
+        -DCMAKE_TARSKI=ON
+        -DCMAKE_DOXYGEN_DOCS=OFF
+        -DCMAKE_DOXYGEN_FLAT_THEME=OFF
+        -DCMAKE_DOXYGEN_AWESOME_THEME=OFF
+        -DCMAKE_SPHINX_DOCS=OFF
+        -DCMAKE_STATIC_BOOST=ON
+        -DCMAKE_TESTING_ENABLED=ON
 
-#     - name: Build
-#       # Build your program with the given configuration
-#       run: > 
-#         cmake --build ${{github.workspace}}/build
+    - name: Build
+      # Build your program with the given configuration
+      run: > 
+        cmake --build ${{github.workspace}}/build
 
-#     - name: Install Python Package
-#       run: python3 -m pip install ${{github.workspace}}/${{env.BUILD_TYPE}}/_package
+    - name: Install Python Package
+      run: python3 -m pip install ${{github.workspace}}/${{env.BUILD_TYPE}}/_package
 
-#     - name: CTest
-#       working-directory: ${{github.workspace}}/build
-#       # Execute tests defined by the CMake configuration.  
-#       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-#       run: ctest
+    - name: CTest
+      working-directory: ${{github.workspace}}/build
+      # Execute tests defined by the CMake configuration.  
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      run: ctest
 
-#     - name: Build Pypi Python Package
-#       run: |
-#         cd ${{github.workspace}}/${{env.BUILD_TYPE}}/_package
-#         python3 setup.py bdist_wheel --plat-name=macosx_10_15_x86_64
+    - uses: jungwinter/split@v2
+      id: split
+      with:
+        msg: ${{ matrix.py_version }}
+        separator: '.'
 
-#     - name: Pytest
-#       working-directory: ${{github.workspace}}
-#       run: |
-#         pytest
+    - name: Build Pypi Python Package
+      run: |
+        cd ${{github.workspace}}/${{env.BUILD_TYPE}}/_package
+        python3 setup.py bdist_wheel --python-tag=cp${{ steps.split.outputs._0 }}${{ steps.split.outputs._1 }} --plat-name=macosx_10_15_x86_64
 
-#     - name: Lint with flake8
-#       run: |
-#         # DON'T[ANU: To be changed later] stop the build if there are Python syntax errors or undefined names
-#         flake8 . --count --exit-zero --select=E9,F63,F7,F82 --show-source --statistics
-#         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-#         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Pytest
+      working-directory: ${{github.workspace}}
+      run: |
+        pytest
+
+    - name: Lint with flake8
+      run: |
+        # DON'T[ANU: To be changed later] stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --exit-zero --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -31,7 +31,7 @@ jobs:
     
     - name: Install platform specific requirements
       run: |
-        sudo apt-get install -y flex bison 
+        sudo apt-get install -y flex bison libfl-dev
       # python3-dev python3 libfl-dev
       
     - name: Set up Python ${{ matrix.py_version }}
@@ -126,7 +126,8 @@ jobs:
     
     - name: Install platform specific requirements
       run: |
-        sudo apt-get install -y flex bison python3-dev python3 libfl-dev
+        sudo apt-get install -y flex bison libfl-dev
+      # python3-dev python3
       
     - name: Set up Python ${{ matrix.py_version }}
       uses: actions/setup-python@v2
@@ -260,11 +261,13 @@ jobs:
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: ctest
 
-    - uses: jungwinter/split@v2
+    - name: Split version code
+      uses: xom9ikk/split@v1
       id: split
       with:
-        msg: ${{ matrix.py_version }}
-        separator: '.'
+        string: ${{ matrix.py_version }}
+        separator: .
+        limit: -1
 
     - name: Build Pypi Python Package
       run: |
@@ -302,9 +305,9 @@ jobs:
         rm -rf ${{github.workspace}}/build
         rm -rf ${{github.workspace}}/${{env.BUILD_TYPE}}
 
-    - name: Install platform specific dependencies
-      run: |
-        brew install flex bison python3 libffi
+    # - name: Install platform specific dependencies
+    #   run: |
+    #     brew install flex bison python3 libffi
 
     - name: Set up Python ${{ matrix.py_version }}
       uses: actions/setup-python@v2
@@ -355,11 +358,13 @@ jobs:
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: ctest
 
-    - uses: jungwinter/split@v2
+    - name: Split version code
+      uses: xom9ikk/split@v1
       id: split
       with:
-        msg: ${{ matrix.py_version }}
-        separator: '.'
+        string: ${{ matrix.py_version }}
+        separator: .
+        limit: -1
 
     - name: Build Pypi Python Package
       run: |
@@ -397,9 +402,9 @@ jobs:
         rm -rf ${{github.workspace}}/build
         rm -rf ${{github.workspace}}/${{env.BUILD_TYPE}}
 
-    - name: Install platform specific dependencies
-      run: |
-        brew install flex bison python3 libffi
+    # - name: Install platform specific dependencies
+    #   run: |
+    #     brew install flex bison python3 libffi
 
     - name: Set up Python ${{ matrix.py_version }}
       uses: actions/setup-python@v2
@@ -450,11 +455,13 @@ jobs:
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: ctest
 
-    - uses: jungwinter/split@v2
+    - name: Split version code
+      uses: xom9ikk/split@v1
       id: split
       with:
-        msg: ${{ matrix.py_version }}
-        separator: '.'
+        string: ${{ matrix.py_version }}
+        separator: .
+        limit: -1
 
     - name: Build Pypi Python Package
       run: |

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        py_version: [3.6, 3.7, 3.8, 3.9, 3.10]
+        py_version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -67,7 +67,7 @@ jobs:
         -DCMAKE_SPHINX_DOCS=ON
         -DCMAKE_STATIC_BOOST=ON
         -DCMAKE_TESTING_ENABLED=ON
-        -DPY_VERSION=${{ matrix.py_version }}
+        -DPY_VERSION="${{ matrix.py_version }}"
 
     - name: Build
       # Build your program with the given configuration
@@ -165,7 +165,7 @@ jobs:
         -DCMAKE_SPHINX_DOCS=OFF 
         -DCMAKE_STATIC_BOOST=ON
         -DCMAKE_TESTING_ENABLED=ON
-        -DPY_VERSION=${{ matrix.py_version }}
+        -DPY_VERSION="${{ matrix.py_version }}"
 
     - name: Build
       # Build your program with the given configuration
@@ -248,7 +248,7 @@ jobs:
         -DCMAKE_SPHINX_DOCS=OFF
         -DCMAKE_STATIC_BOOST=ON
         -DCMAKE_TESTING_ENABLED=ON
-        -DPY_VERSION=${{ matrix.py_version }}
+        -DPY_VERSION="${{ matrix.py_version }}"
 
     - name: Build
       # Build your program with the given configuration
@@ -346,7 +346,7 @@ jobs:
         -DCMAKE_SPHINX_DOCS=OFF
         -DCMAKE_STATIC_BOOST=ON
         -DCMAKE_TESTING_ENABLED=ON
-        -DPY_VERSION=${{ matrix.py_version }}
+        -DPY_VERSION="${{ matrix.py_version }}"
 
     - name: Build
       # Build your program with the given configuration
@@ -444,7 +444,7 @@ jobs:
         -DCMAKE_SPHINX_DOCS=OFF
         -DCMAKE_STATIC_BOOST=ON
         -DCMAKE_TESTING_ENABLED=ON
-        -DPY_VERSION=${{ matrix.py_version }}
+        -DPY_VERSION="${{ matrix.py_version }}"
 
     - name: Build
       # Build your program with the given configuration

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -67,6 +67,7 @@ jobs:
         -DCMAKE_SPHINX_DOCS=ON
         -DCMAKE_STATIC_BOOST=ON
         -DCMAKE_TESTING_ENABLED=ON
+        -DPY_VERSION=${{ matrix.py_version }}
 
     - name: Build
       # Build your program with the given configuration
@@ -164,6 +165,7 @@ jobs:
         -DCMAKE_SPHINX_DOCS=OFF 
         -DCMAKE_STATIC_BOOST=ON
         -DCMAKE_TESTING_ENABLED=ON
+        -DPY_VERSION=${{ matrix.py_version }}
 
     - name: Build
       # Build your program with the given configuration
@@ -246,6 +248,7 @@ jobs:
         -DCMAKE_SPHINX_DOCS=OFF
         -DCMAKE_STATIC_BOOST=ON
         -DCMAKE_TESTING_ENABLED=ON
+        -DPY_VERSION=${{ matrix.py_version }}
 
     - name: Build
       # Build your program with the given configuration
@@ -277,7 +280,7 @@ jobs:
     - name: Pytest
       working-directory: ${{github.workspace}}
       run: |
-        pytest
+        py -m pytest
 
     - name: Lint with flake8
       run: |
@@ -343,6 +346,7 @@ jobs:
         -DCMAKE_SPHINX_DOCS=OFF
         -DCMAKE_STATIC_BOOST=ON
         -DCMAKE_TESTING_ENABLED=ON
+        -DPY_VERSION=${{ matrix.py_version }}
 
     - name: Build
       # Build your program with the given configuration
@@ -440,6 +444,7 @@ jobs:
         -DCMAKE_SPHINX_DOCS=OFF
         -DCMAKE_STATIC_BOOST=ON
         -DCMAKE_TESTING_ENABLED=ON
+        -DPY_VERSION=${{ matrix.py_version }}
 
     - name: Build
       # Build your program with the given configuration

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -215,7 +215,7 @@ jobs:
       matrix:
         py_version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
         exclude:
-          - py_version: "3.8"
+          - py_version: "3.6"
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -287,9 +287,9 @@ jobs:
     - name: Lint with flake8
       run: |
         # DON'T[ANU: To be changed later] stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --exit-zero --select=E9,F63,F7,F82 --show-source --statistics
+        py -m flake8 . --count --exit-zero --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        py -m flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
 # --------------------------------------------------------------------------- #
 

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -83,9 +83,9 @@ jobs:
       run: ctest
 
     - uses: jungwinter/split@v2
-        id: split
-        with:
-          msg: ${{ matrix.py_version }}
+      id: split
+      with:
+        msg: ${{ matrix.py_version }}
 
     - name: Build Pypi Python Package
       run: |

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -11,7 +11,6 @@ name: PypiPublish
 on:
   release:
     types: [published]
-    branches:  [main]
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
@@ -19,11 +18,16 @@ env:
 
 jobs:
 
+# --------------------------------------------------------------------------- #
+
   build-ubuntu-20:
     # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
     # You can convert this to a matrix build if you need cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        py_version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2
@@ -32,15 +36,23 @@ jobs:
       run: | 
         rm -rf ${{github.workspace}}/build
         rm -rf ${{github.workspace}}/${{env.BUILD_TYPE}}
+    
+    # - name: Install platform specific requirements
+    #   run: |
+    #     sudo apt-get install -y flex bison python3-dev python3 libfl-dev
       
-    - name: Set up Python 3.10
+    - name: Set up Python ${{ matrix.py_version }}
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "${{ matrix.py_version }}"
 
-    - name: Install dependencies
+    - name: Print GLIBC version
+      run: ldd --version
+
+    - name: Install pip dependencies
       run: |
         python3 -m pip install --upgrade pip
+        python3 -m pip install flake8 pytest
         python3 -m pip install --upgrade build wheel twine
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
@@ -51,28 +63,65 @@ jobs:
         cmake -B ${{github.workspace}}/build 
         -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
         -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/${{env.BUILD_TYPE}}
+        -DUSE_SUPERBUILD=ON
+        -DCMAKE_FF_CXX=OFF
+        -DCMAKE_LEGACY_PLANNER=OFF
+        -DCMAKE_FD=OFF
+        -DCMAKE_TARSKI=ON
+        -DCMAKE_DOXYGEN_DOCS=ON
+        -DCMAKE_DOXYGEN_FLAT_THEME=ON
+        -DCMAKE_DOXYGEN_AWESOME_THEME=ON
+        -DCMAKE_SPHINX_DOCS=ON
+        -DCMAKE_STATIC_BOOST=ON
+        -DCMAKE_TESTING_ENABLED=ON
+        -DPY_VERSION="${{ matrix.py_version }}"
 
     - name: Build
       # Build your program with the given configuration
       run: > 
-        cmake --build ${{github.workspace}}/build --target install
+        cmake --build ${{github.workspace}}/build
+
+    - name: Install Python Package
+      run: python3 -m pip install ${{github.workspace}}/${{env.BUILD_TYPE}}/_package
+
+    - name: CTest
+      working-directory: ${{github.workspace}}/build
+      # Execute tests defined by the CMake configuration.  
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      run: ctest
+
+    - uses: jungwinter/split@v2
+      id: split
+      with:
+        msg: ${{ matrix.py_version }}
+        separator: '.'
 
     - name: Build Pypi Python Package
       run: |
-        cd ${{github.workspace}}/${{env.BUILD_TYPE}}/pypi_release
-        python3 setup.py bdist_wheel --plat-name=manylinux_2_31_x86_64
+        cd ${{github.workspace}}/${{env.BUILD_TYPE}}/_package
+        python3 setup.py bdist_wheel --python-tag=cp${{ steps.split.outputs._0 }}${{ steps.split.outputs._1 }} --plat-name=manylinux_2_31_x86_64
+
+    - name: Pytest
+      working-directory: ${{github.workspace}}
+      run: |
+        pytest
 
     - name: Store the binary wheel
       uses: actions/upload-artifact@v2
       with:
         name: python-package-distributions
-        path: ${{github.workspace}}/${{env.BUILD_TYPE}}/pypi_release/dist
+        path: ${{github.workspace}}/${{env.BUILD_TYPE}}/_package/dist
+
+# --------------------------------------------------------------------------- #
 
   build-ubuntu-18:
     # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
     # You can convert this to a matrix build if you need cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
     runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        py_version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2
@@ -81,67 +130,24 @@ jobs:
       run: | 
         rm -rf ${{github.workspace}}/build
         rm -rf ${{github.workspace}}/${{env.BUILD_TYPE}}
+    
+    # - name: Install platform specific requirements
+    #   run: |
+    #     sudo apt-get install -y flex bison python3-dev python3 libfl-dev
       
-    - name: Set up Python 3.10
+    - name: Set up Python ${{ matrix.py_version }}
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "${{ matrix.py_version }}"
 
-    - name: Install dependencies
-      run: |
-        python3 -m pip install --upgrade pip
-        python3 -m pip install --upgrade build wheel twine
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Print GLIBC version
+      run: ldd --version
 
-    - name: Configure CMake
-      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: > 
-        cmake -B ${{github.workspace}}/build 
-        -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
-        -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/${{env.BUILD_TYPE}}
-
-    - name: Build
-      # Build your program with the given configuration
-      run: > 
-        cmake --build ${{github.workspace}}/build --target install
-
-    - name: Build Pypi Python Package
-      run: |
-        cd ${{github.workspace}}/${{env.BUILD_TYPE}}/pypi_release
-        python3 setup.py bdist_wheel --plat-name=manylinux_2_27_x86_64
-
-    - name: Store the binary wheel
-      uses: actions/upload-artifact@v2
-      with:
-        name: python-package-distributions
-        path: ${{github.workspace}}/${{env.BUILD_TYPE}}/pypi_release/dist
-
-  build-macos-latest:
-    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
-    # You can convert this to a matrix build if you need cross-platform coverage.
-    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: macos-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Remove previous builds if any
-      run: | 
-        rm -rf ${{github.workspace}}/build
-        rm -rf ${{github.workspace}}/${{env.BUILD_TYPE}}
-
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v2
-      with:
-        python-version: "3.10"
-
-    - name: Install dependencies
+    - name: Install pip dependencies
       run: |
         python3 -m pip install --upgrade pip
         python3 -m pip install flake8 pytest
         python3 -m pip install --upgrade build wheel twine
-        brew install gcc@10
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
     - name: Configure CMake
@@ -151,95 +157,77 @@ jobs:
         cmake -B ${{github.workspace}}/build 
         -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
         -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/${{env.BUILD_TYPE}}
-        -DCMAKE_GENERATOR="Unix Makefiles"
-        -DCMAKE_C_COMPILER=gcc-10
-        -DCMAKE_CXX_COMPILER=g++-10
+        -DUSE_SUPERBUILD=ON
+        -DCMAKE_FF_CXX=OFF
+        -DCMAKE_LEGACY_PLANNER=OFF
+        -DCMAKE_FD=OFF
+        -DCMAKE_TARSKI=ON
+        -DCMAKE_DOXYGEN_DOCS=OFF
+        -DCMAKE_DOXYGEN_FLAT_THEME=OFF
+        -DCMAKE_DOXYGEN_AWESOME_THEME=OFF
+        -DCMAKE_SPHINX_DOCS=OFF
+        -DCMAKE_STATIC_BOOST=ON
+        -DCMAKE_TESTING_ENABLED=ON
+        -DPY_VERSION="${{ matrix.py_version }}"
 
     - name: Build
       # Build your program with the given configuration
       run: > 
-        cmake --build ${{github.workspace}}/build --target install
+        cmake --build ${{github.workspace}}/build
+
+    - name: Install Python Package
+      run: python3 -m pip install ${{github.workspace}}/${{env.BUILD_TYPE}}/_package
+
+    - name: CTest
+      working-directory: ${{github.workspace}}/build
+      # Execute tests defined by the CMake configuration.  
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      run: ctest
+
+    - uses: jungwinter/split@v2
+      id: split
+      with:
+        msg: ${{ matrix.py_version }}
+        separator: '.'
 
     - name: Build Pypi Python Package
       run: |
-        cd ${{github.workspace}}/${{env.BUILD_TYPE}}/pypi_release
-        python3 setup.py bdist_wheel --plat-name=macosx_11_0_x86_64
+        cd ${{github.workspace}}/${{env.BUILD_TYPE}}/_package
+        python3 setup.py bdist_wheel --python-tag=cp${{ steps.split.outputs._0 }}${{ steps.split.outputs._1 }} --plat-name=manylinux_2_27_x86_64
+
+    - name: Pytest
+      working-directory: ${{github.workspace}}
+      run: |
+        pytest
 
     - name: Store the binary wheel
       uses: actions/upload-artifact@v2
       with:
         name: python-package-distributions
-        path: ${{github.workspace}}/${{env.BUILD_TYPE}}/pypi_release/dist
+        path: ${{github.workspace}}/${{env.BUILD_TYPE}}/_package/dist
 
-  build-macos-10_15:
+# --------------------------------------------------------------------------- #
+
+  build-windows-2019:
     # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
     # You can convert this to a matrix build if you need cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: macos-10.15
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Remove previous builds if any
-      run: | 
-        rm -rf ${{github.workspace}}/build
-        rm -rf ${{github.workspace}}/${{env.BUILD_TYPE}}
-
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v2
-      with:
-        python-version: "3.10"
-
-    - name: Install dependencies
-      run: |
-        python3 -m pip install --upgrade pip
-        python3 -m pip install flake8 pytest
-        python3 -m pip install --upgrade build wheel twine
-        brew install gcc@10
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-
-    - name: Configure CMake
-      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: > 
-        cmake -B ${{github.workspace}}/build 
-        -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
-        -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/${{env.BUILD_TYPE}}
-        -DCMAKE_GENERATOR="Unix Makefiles"
-        -DCMAKE_C_COMPILER=gcc-10
-        -DCMAKE_CXX_COMPILER=g++-10
-
-    - name: Build
-      # Build your program with the given configuration
-      run: > 
-        cmake --build ${{github.workspace}}/build --target install
-
-    - name: Build Pypi Python Package
-      run: |
-        cd ${{github.workspace}}/${{env.BUILD_TYPE}}/pypi_release
-        python3 setup.py bdist_wheel --plat-name=macosx_10_15_x86_64
-
-    - name: Store the binary wheel
-      uses: actions/upload-artifact@v2
-      with:
-        name: python-package-distributions
-        path: ${{github.workspace}}/${{env.BUILD_TYPE}}/pypi_release/dist
-
-  build-windows-latest:
-    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
-    # You can convert this to a matrix build if you need cross-platform coverage.
-    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: windows-latest
+    runs-on: windows-2019
+    strategy:
+      matrix:
+        py_version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        exclude:
+          - py_version: "3.6"
 
     steps:
     - uses: actions/checkout@v2
       
-    - name: Set up Python 3.10
+    - name: Set up Python ${{ matrix.py_version }}
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "${{ matrix.py_version }}"
 
-    - name: Install dependencies
+    - name: Install pip dependencies
       run: |
         py -m pip install --upgrade pip
         py -m pip install flake8 pytest
@@ -253,31 +241,266 @@ jobs:
         -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
         -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/${{env.BUILD_TYPE}}
         -DCMAKE_GENERATOR="MinGW Makefiles"
+        -DUSE_SUPERBUILD=ON
+        -DCMAKE_FF_CXX=OFF
+        -DCMAKE_LEGACY_PLANNER=OFF
+        -DCMAKE_FD=OFF
+        -DCMAKE_TARSKI=ON
+        -DCMAKE_DOXYGEN_DOCS=OFF
+        -DCMAKE_DOXYGEN_FLAT_THEME=OFF
+        -DCMAKE_DOXYGEN_AWESOME_THEME=OFF
+        -DCMAKE_SPHINX_DOCS=OFF
+        -DCMAKE_STATIC_BOOST=ON
+        -DCMAKE_TESTING_ENABLED=ON
+        -DPY_VERSION="${{ matrix.py_version }}"
 
     - name: Build
       # Build your program with the given configuration
       run: > 
-        cmake --build ${{github.workspace}}/build --target install
+        cmake --build ${{github.workspace}}/build
+
+    - name: Install Python Package
+      run: py -m pip install ${{github.workspace}}/${{env.BUILD_TYPE}}/_package
+
+    - name: CTest
+      working-directory: ${{github.workspace}}/build
+      # Execute tests defined by the CMake configuration.  
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      run: ctest
+
+    - name: Split version code
+      uses: xom9ikk/split@v1
+      id: split
+      with:
+        string: ${{ matrix.py_version }}
+        separator: .
+        limit: -1
 
     - name: Build Pypi Python Package
       run: |
-        cd ${{github.workspace}}/${{env.BUILD_TYPE}}/pypi_release
-        py setup.py bdist_wheel --plat-name=win_amd64
+        cd ${{github.workspace}}/${{env.BUILD_TYPE}}/_package
+        py setup.py bdist_wheel --python-tag=cp${{ steps.split.outputs._0 }}${{ steps.split.outputs._1 }} --plat-name=win_amd64
+
+    - name: Pytest
+      working-directory: ${{github.workspace}}
+      run: |
+        py -m pytest
 
     - name: Store the binary wheel
       uses: actions/upload-artifact@v2
       with:
         name: python-package-distributions
-        path: ${{github.workspace}}/${{env.BUILD_TYPE}}/pypi_release/dist
+        path: ${{github.workspace}}/${{env.BUILD_TYPE}}/_package/dist
+
+# --------------------------------------------------------------------------- #
+
+  build-macos-11:
+    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
+    # You can convert this to a matrix build if you need cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    runs-on: macos-11
+    strategy:
+      matrix:
+        py_version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        exclude:
+          - py_version: "3.8"
+
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Remove previous builds if any
+      run: | 
+        rm -rf ${{github.workspace}}/build
+        rm -rf ${{github.workspace}}/${{env.BUILD_TYPE}}
+
+    # - name: Install platform specific dependencies
+    #   run: |
+    #     brew install flex bison python3 libffi
+
+    - name: Set up Python ${{ matrix.py_version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: "${{ matrix.py_version }}"
+
+    - name: Install pip dependencies
+      run: |
+        python3 -m pip install --upgrade pip
+        python3 -m pip install flake8 pytest
+        python3 -m pip install --upgrade build wheel twine
+        brew install gcc@10
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
+    - name: Configure CMake
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: > 
+        cmake -B ${{github.workspace}}/build 
+        -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+        -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/${{env.BUILD_TYPE}}
+        -DCMAKE_GENERATOR="Unix Makefiles"
+        -DCMAKE_C_COMPILER=gcc-10
+        -DCMAKE_CXX_COMPILER=g++-10
+        -DUSE_SUPERBUILD=ON
+        -DCMAKE_FF_CXX=OFF
+        -DCMAKE_LEGACY_PLANNER=OFF
+        -DCMAKE_FD=OFF
+        -DCMAKE_TARSKI=ON
+        -DCMAKE_DOXYGEN_DOCS=OFF
+        -DCMAKE_DOXYGEN_FLAT_THEME=OFF
+        -DCMAKE_DOXYGEN_AWESOME_THEME=OFF
+        -DCMAKE_SPHINX_DOCS=OFF
+        -DCMAKE_STATIC_BOOST=ON
+        -DCMAKE_TESTING_ENABLED=ON
+        -DPY_VERSION="${{ matrix.py_version }}"
+
+    - name: Build
+      # Build your program with the given configuration
+      run: > 
+        cmake --build ${{github.workspace}}/build
+
+    - name: Install Python Package
+      run: python3 -m pip install ${{github.workspace}}/${{env.BUILD_TYPE}}/_package
+
+    - name: CTest
+      working-directory: ${{github.workspace}}/build
+      # Execute tests defined by the CMake configuration.  
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      run: ctest
+
+    - name: Split version code
+      uses: xom9ikk/split@v1
+      id: split
+      with:
+        string: ${{ matrix.py_version }}
+        separator: .
+        limit: -1
+
+    - name: Build Pypi Python Package
+      run: |
+        cd ${{github.workspace}}/${{env.BUILD_TYPE}}/_package
+        python3 setup.py bdist_wheel --python-tag=cp${{ steps.split.outputs._0 }}${{ steps.split.outputs._1 }} --plat-name=macosx_11_0_x86_64
+
+    - name: Pytest
+      working-directory: ${{github.workspace}}
+      run: |
+        pytest
+
+    - name: Store the binary wheel
+      uses: actions/upload-artifact@v2
+      with:
+        name: python-package-distributions
+        path: ${{github.workspace}}/${{env.BUILD_TYPE}}/_package/dist
+
+# --------------------------------------------------------------------------- #
+
+  build-macos-10_15:
+    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
+    # You can convert this to a matrix build if you need cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    runs-on: macos-10.15
+    strategy:
+      matrix:
+        py_version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        exclude:
+          - py_version: "3.8"
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Remove previous builds if any
+      run: | 
+        rm -rf ${{github.workspace}}/build
+        rm -rf ${{github.workspace}}/${{env.BUILD_TYPE}}
+
+    # - name: Install platform specific dependencies
+    #   run: |
+    #     brew install flex bison python3 libffi
+
+    - name: Set up Python ${{ matrix.py_version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: "${{ matrix.py_version }}"
+
+    - name: Install dependencies
+      run: |
+        python3 -m pip install --upgrade pip
+        python3 -m pip install flake8 pytest
+        python3 -m pip install --upgrade build wheel twine
+        brew install gcc@10
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
+    - name: Configure CMake
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: > 
+        cmake -B ${{github.workspace}}/build 
+        -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+        -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/${{env.BUILD_TYPE}}
+        -DCMAKE_GENERATOR="Unix Makefiles"
+        -DCMAKE_C_COMPILER=gcc-10
+        -DCMAKE_CXX_COMPILER=g++-10
+        -DUSE_SUPERBUILD=ON
+        -DCMAKE_FF_CXX=OFF
+        -DCMAKE_LEGACY_PLANNER=OFF
+        -DCMAKE_FD=OFF
+        -DCMAKE_TARSKI=ON
+        -DCMAKE_DOXYGEN_DOCS=OFF
+        -DCMAKE_DOXYGEN_FLAT_THEME=OFF
+        -DCMAKE_DOXYGEN_AWESOME_THEME=OFF
+        -DCMAKE_SPHINX_DOCS=OFF
+        -DCMAKE_STATIC_BOOST=ON
+        -DCMAKE_TESTING_ENABLED=ON
+        -DPY_VERSION="${{ matrix.py_version }}"
+
+    - name: Build
+      # Build your program with the given configuration
+      run: > 
+        cmake --build ${{github.workspace}}/build
+
+    - name: Install Python Package
+      run: python3 -m pip install ${{github.workspace}}/${{env.BUILD_TYPE}}/_package
+
+    - name: CTest
+      working-directory: ${{github.workspace}}/build
+      # Execute tests defined by the CMake configuration.  
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      run: ctest
+
+    - name: Split version code
+      uses: xom9ikk/split@v1
+      id: split
+      with:
+        string: ${{ matrix.py_version }}
+        separator: .
+        limit: -1
+
+    - name: Build Pypi Python Package
+      run: |
+        cd ${{github.workspace}}/${{env.BUILD_TYPE}}/_package
+        python3 setup.py bdist_wheel --python-tag=cp${{ steps.split.outputs._0 }}${{ steps.split.outputs._1 }} --plat-name=macosx_10_15_x86_64
+
+    - name: Pytest
+      working-directory: ${{github.workspace}}
+      run: |
+        pytest
+
+    - name: Store the binary wheel
+      uses: actions/upload-artifact@v2
+      with:
+        name: python-package-distributions
+        path: ${{github.workspace}}/${{env.BUILD_TYPE}}/_package/dist
+
+# --------------------------------------------------------------------------- #
 
   deploy:
     # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
     # You can convert this to a matrix build if you need cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
     needs:
-    - build-windows-latest
+    - build-windows-2019
     - build-macos-10_15
-    - build-macos-latest
+    - build-macos-11
     - build-ubuntu-18
     - build-ubuntu-20
 
@@ -309,4 +532,3 @@ jobs:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}
         packages_dir: dist
-

--- a/.github/workflows/testpypi_publish.yml
+++ b/.github/workflows/testpypi_publish.yml
@@ -215,6 +215,8 @@ jobs:
     strategy:
       matrix:
         py_version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        exclude:
+          - py_version: "3.6"
 
     steps:
     - uses: actions/checkout@v2
@@ -281,7 +283,7 @@ jobs:
     - name: Pytest
       working-directory: ${{github.workspace}}
       run: |
-        pytest
+        py -m pytest
 
     - name: Store the binary wheel
       uses: actions/upload-artifact@v2
@@ -299,6 +301,8 @@ jobs:
     strategy:
       matrix:
         py_version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        exclude:
+          - py_version: "3.8"
 
 
     steps:
@@ -397,6 +401,8 @@ jobs:
     strategy:
       matrix:
         py_version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        exclude:
+          - py_version: "3.8"
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/testpypi_publish.yml
+++ b/.github/workflows/testpypi_publish.yml
@@ -24,6 +24,9 @@ jobs:
     # You can convert this to a matrix build if you need cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        py_version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2
@@ -33,14 +36,14 @@ jobs:
         rm -rf ${{github.workspace}}/build
         rm -rf ${{github.workspace}}/${{env.BUILD_TYPE}}
     
-    - name: Install platform specific requirements
-      run: |
-        sudo apt-get install -y flex bison python3-dev python3 libfl-dev
+    # - name: Install platform specific requirements
+    #   run: |
+    #     sudo apt-get install -y flex bison python3-dev python3 libfl-dev
       
-    - name: Set up Python 3.10
+    - name: Set up Python ${{ matrix.py_version }}
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "${{ matrix.py_version }}"
 
     - name: Print GLIBC version
       run: ldd --version
@@ -85,10 +88,16 @@ jobs:
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: ctest
 
+    - uses: jungwinter/split@v2
+      id: split
+      with:
+        msg: ${{ matrix.py_version }}
+        separator: '.'
+
     - name: Build Pypi Python Package
       run: |
         cd ${{github.workspace}}/${{env.BUILD_TYPE}}/_package
-        python3 setup.py bdist_wheel --plat-name=manylinux_2_31_x86_64
+        python3 setup.py bdist_wheel --python-tag=cp${{ steps.split.outputs._0 }}${{ steps.split.outputs._1 }} --plat-name=manylinux_2_31_x86_64
 
     - name: Pytest
       working-directory: ${{github.workspace}}
@@ -108,6 +117,9 @@ jobs:
     # You can convert this to a matrix build if you need cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
     runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        py_version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2
@@ -117,14 +129,14 @@ jobs:
         rm -rf ${{github.workspace}}/build
         rm -rf ${{github.workspace}}/${{env.BUILD_TYPE}}
     
-    - name: Install platform specific requirements
-      run: |
-        sudo apt-get install -y flex bison python3-dev python3 libfl-dev
+    # - name: Install platform specific requirements
+    #   run: |
+    #     sudo apt-get install -y flex bison python3-dev python3 libfl-dev
       
-    - name: Set up Python 3.10
+    - name: Set up Python ${{ matrix.py_version }}
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "${{ matrix.py_version }}"
 
     - name: Print GLIBC version
       run: ldd --version
@@ -169,10 +181,99 @@ jobs:
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: ctest
 
+    - uses: jungwinter/split@v2
+      id: split
+      with:
+        msg: ${{ matrix.py_version }}
+        separator: '.'
+
     - name: Build Pypi Python Package
       run: |
         cd ${{github.workspace}}/${{env.BUILD_TYPE}}/_package
-        python3 setup.py bdist_wheel --plat-name=manylinux_2_27_x86_64
+        python3 setup.py bdist_wheel --python-tag=cp${{ steps.split.outputs._0 }}${{ steps.split.outputs._1 }} --plat-name=manylinux_2_27_x86_64
+
+    - name: Pytest
+      working-directory: ${{github.workspace}}
+      run: |
+        pytest
+
+    - name: Store the binary wheel
+      uses: actions/upload-artifact@v2
+      with:
+        name: python-package-distributions
+        path: ${{github.workspace}}/${{env.BUILD_TYPE}}/_package/dist
+
+# --------------------------------------------------------------------------- #
+
+  build-windows-2019:
+    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
+    # You can convert this to a matrix build if you need cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    runs-on: windows-2019
+    strategy:
+      matrix:
+        py_version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+
+    steps:
+    - uses: actions/checkout@v2
+      
+    - name: Set up Python ${{ matrix.py_version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: "${{ matrix.py_version }}"
+
+    - name: Install pip dependencies
+      run: |
+        py -m pip install --upgrade pip
+        py -m pip install flake8 pytest
+        py -m pip install --upgrade build wheel twine
+
+    - name: Configure CMake
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: > 
+        cmake -B ${{github.workspace}}/build 
+        -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+        -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/${{env.BUILD_TYPE}}
+        -DCMAKE_GENERATOR="MinGW Makefiles"
+        -DUSE_SUPERBUILD=ON
+        -DCMAKE_FF_CXX=OFF
+        -DCMAKE_LEGACY_PLANNER=OFF
+        -DCMAKE_FD=OFF
+        -DCMAKE_TARSKI=ON
+        -DCMAKE_DOXYGEN_DOCS=OFF
+        -DCMAKE_DOXYGEN_FLAT_THEME=OFF
+        -DCMAKE_DOXYGEN_AWESOME_THEME=OFF
+        -DCMAKE_SPHINX_DOCS=OFF
+        -DCMAKE_STATIC_BOOST=ON
+        -DCMAKE_TESTING_ENABLED=ON
+
+    - name: Build
+      # Build your program with the given configuration
+      run: > 
+        cmake --build ${{github.workspace}}/build
+
+    - name: Install Python Package
+      run: py -m pip install ${{github.workspace}}/${{env.BUILD_TYPE}}/_package
+
+    - name: CTest
+      working-directory: ${{github.workspace}}/build
+      # Execute tests defined by the CMake configuration.  
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      run: ctest
+
+    - name: Split version code
+      uses: xom9ikk/split@v1
+      id: split
+      with:
+        string: ${{ matrix.py_version }}
+        separator: .
+        limit: -1
+
+    - name: Build Pypi Python Package
+      run: |
+        cd ${{github.workspace}}/${{env.BUILD_TYPE}}/_package
+        py setup.py bdist_wheel --python-tag=cp${{ steps.split.outputs._0 }}${{ steps.split.outputs._1 }} --plat-name=win_amd64
 
     - name: Pytest
       working-directory: ${{github.workspace}}
@@ -192,6 +293,10 @@ jobs:
     # You can convert this to a matrix build if you need cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
     runs-on: macos-11
+    strategy:
+      matrix:
+        py_version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+
 
     steps:
     - uses: actions/checkout@v2
@@ -201,14 +306,14 @@ jobs:
         rm -rf ${{github.workspace}}/build
         rm -rf ${{github.workspace}}/${{env.BUILD_TYPE}}
 
-    - name: Install platform specific dependencies
-      run: |
-        brew install flex bison python3 libffi
+    # - name: Install platform specific dependencies
+    #   run: |
+    #     brew install flex bison python3 libffi
 
-    - name: Set up Python 3.10
+    - name: Set up Python ${{ matrix.py_version }}
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "${{ matrix.py_version }}"
 
     - name: Install pip dependencies
       run: |
@@ -248,16 +353,24 @@ jobs:
     - name: Install Python Package
       run: python3 -m pip install ${{github.workspace}}/${{env.BUILD_TYPE}}/_package
 
-    # - name: CTest
-    #   working-directory: ${{github.workspace}}/build
-    #   # Execute tests defined by the CMake configuration.  
-    #   # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-    #   run: ctest
+    - name: CTest
+      working-directory: ${{github.workspace}}/build
+      # Execute tests defined by the CMake configuration.  
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      run: ctest
+
+    - name: Split version code
+      uses: xom9ikk/split@v1
+      id: split
+      with:
+        string: ${{ matrix.py_version }}
+        separator: .
+        limit: -1
 
     - name: Build Pypi Python Package
       run: |
         cd ${{github.workspace}}/${{env.BUILD_TYPE}}/_package
-        python3 setup.py bdist_wheel --plat-name=macosx_11_0_x86_64
+        python3 setup.py bdist_wheel --python-tag=cp${{ steps.split.outputs._0 }}${{ steps.split.outputs._1 }} --plat-name=macosx_11_0_x86_64
 
     - name: Pytest
       working-directory: ${{github.workspace}}
@@ -277,6 +390,9 @@ jobs:
     # You can convert this to a matrix build if you need cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
     runs-on: macos-10.15
+    strategy:
+      matrix:
+        py_version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2
@@ -286,14 +402,14 @@ jobs:
         rm -rf ${{github.workspace}}/build
         rm -rf ${{github.workspace}}/${{env.BUILD_TYPE}}
 
-    - name: Install platform specific dependencies
-      run: |
-        brew install flex bison python3 libffi
+    # - name: Install platform specific dependencies
+    #   run: |
+    #     brew install flex bison python3 libffi
 
-    - name: Set up Python 3.10
+    - name: Set up Python ${{ matrix.py_version }}
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "${{ matrix.py_version }}"
 
     - name: Install dependencies
       run: |
@@ -339,82 +455,18 @@ jobs:
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: ctest
 
-    - name: Build Pypi Python Package
-      run: |
-        cd ${{github.workspace}}/${{env.BUILD_TYPE}}/_package
-        python3 setup.py bdist_wheel --plat-name=macosx_10_15_x86_64
-
-    - name: Pytest
-      working-directory: ${{github.workspace}}
-      run: |
-        pytest
-
-    - name: Store the binary wheel
-      uses: actions/upload-artifact@v2
+    - name: Split version code
+      uses: xom9ikk/split@v1
+      id: split
       with:
-        name: python-package-distributions
-        path: ${{github.workspace}}/${{env.BUILD_TYPE}}/_package/dist
-
-# --------------------------------------------------------------------------- #
-
-  build-windows-2019:
-    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
-    # You can convert this to a matrix build if you need cross-platform coverage.
-    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: windows-2019
-
-    steps:
-    - uses: actions/checkout@v2
-      
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v2
-      with:
-        python-version: "3.10"
-
-    - name: Install pip dependencies
-      run: |
-        py -m pip install --upgrade pip
-        py -m pip install flake8 pytest
-        py -m pip install --upgrade build wheel twine
-
-    - name: Configure CMake
-      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: > 
-        cmake -B ${{github.workspace}}/build 
-        -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
-        -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/${{env.BUILD_TYPE}}
-        -DCMAKE_GENERATOR="MinGW Makefiles"
-        -DUSE_SUPERBUILD=ON
-        -DCMAKE_FF_CXX=OFF
-        -DCMAKE_LEGACY_PLANNER=OFF
-        -DCMAKE_FD=OFF
-        -DCMAKE_TARSKI=ON
-        -DCMAKE_DOXYGEN_DOCS=OFF
-        -DCMAKE_DOXYGEN_FLAT_THEME=OFF
-        -DCMAKE_DOXYGEN_AWESOME_THEME=OFF
-        -DCMAKE_SPHINX_DOCS=OFF
-        -DCMAKE_STATIC_BOOST=ON
-        -DCMAKE_TESTING_ENABLED=ON
-
-    - name: Build
-      # Build your program with the given configuration
-      run: > 
-        cmake --build ${{github.workspace}}/build
-
-    - name: Install Python Package
-      run: py -m pip install ${{github.workspace}}/${{env.BUILD_TYPE}}/_package
-
-    - name: CTest
-      working-directory: ${{github.workspace}}/build
-      # Execute tests defined by the CMake configuration.  
-      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest
+        string: ${{ matrix.py_version }}
+        separator: .
+        limit: -1
 
     - name: Build Pypi Python Package
       run: |
         cd ${{github.workspace}}/${{env.BUILD_TYPE}}/_package
-        py setup.py bdist_wheel --plat-name=win_amd64
+        python3 setup.py bdist_wheel --python-tag=cp${{ steps.split.outputs._0 }}${{ steps.split.outputs._1 }} --plat-name=macosx_10_15_x86_64
 
     - name: Pytest
       working-directory: ${{github.workspace}}

--- a/.github/workflows/testpypi_publish.yml
+++ b/.github/workflows/testpypi_publish.yml
@@ -73,6 +73,7 @@ jobs:
         -DCMAKE_SPHINX_DOCS=ON
         -DCMAKE_STATIC_BOOST=ON
         -DCMAKE_TESTING_ENABLED=ON
+        -DPY_VERSION=${{ matrix.py_version }}
 
     - name: Build
       # Build your program with the given configuration
@@ -166,6 +167,7 @@ jobs:
         -DCMAKE_SPHINX_DOCS=OFF
         -DCMAKE_STATIC_BOOST=ON
         -DCMAKE_TESTING_ENABLED=ON
+        -DPY_VERSION=${{ matrix.py_version }}
 
     - name: Build
       # Build your program with the given configuration
@@ -247,6 +249,7 @@ jobs:
         -DCMAKE_SPHINX_DOCS=OFF
         -DCMAKE_STATIC_BOOST=ON
         -DCMAKE_TESTING_ENABLED=ON
+        -DPY_VERSION=${{ matrix.py_version }}
 
     - name: Build
       # Build your program with the given configuration
@@ -344,6 +347,7 @@ jobs:
         -DCMAKE_SPHINX_DOCS=OFF
         -DCMAKE_STATIC_BOOST=ON
         -DCMAKE_TESTING_ENABLED=ON
+        -DPY_VERSION=${{ matrix.py_version }}
 
     - name: Build
       # Build your program with the given configuration
@@ -440,6 +444,7 @@ jobs:
         -DCMAKE_SPHINX_DOCS=OFF
         -DCMAKE_STATIC_BOOST=ON
         -DCMAKE_TESTING_ENABLED=ON
+        -DPY_VERSION=${{ matrix.py_version }}
 
     - name: Build
       # Build your program with the given configuration

--- a/.github/workflows/testpypi_publish.yml
+++ b/.github/workflows/testpypi_publish.yml
@@ -73,7 +73,7 @@ jobs:
         -DCMAKE_SPHINX_DOCS=ON
         -DCMAKE_STATIC_BOOST=ON
         -DCMAKE_TESTING_ENABLED=ON
-        -DPY_VERSION=${{ matrix.py_version }}
+        -DPY_VERSION="${{ matrix.py_version }}"
 
     - name: Build
       # Build your program with the given configuration
@@ -167,7 +167,7 @@ jobs:
         -DCMAKE_SPHINX_DOCS=OFF
         -DCMAKE_STATIC_BOOST=ON
         -DCMAKE_TESTING_ENABLED=ON
-        -DPY_VERSION=${{ matrix.py_version }}
+        -DPY_VERSION="${{ matrix.py_version }}"
 
     - name: Build
       # Build your program with the given configuration
@@ -249,7 +249,7 @@ jobs:
         -DCMAKE_SPHINX_DOCS=OFF
         -DCMAKE_STATIC_BOOST=ON
         -DCMAKE_TESTING_ENABLED=ON
-        -DPY_VERSION=${{ matrix.py_version }}
+        -DPY_VERSION="${{ matrix.py_version }}"
 
     - name: Build
       # Build your program with the given configuration
@@ -347,7 +347,7 @@ jobs:
         -DCMAKE_SPHINX_DOCS=OFF
         -DCMAKE_STATIC_BOOST=ON
         -DCMAKE_TESTING_ENABLED=ON
-        -DPY_VERSION=${{ matrix.py_version }}
+        -DPY_VERSION="${{ matrix.py_version }}"
 
     - name: Build
       # Build your program with the given configuration
@@ -444,7 +444,7 @@ jobs:
         -DCMAKE_SPHINX_DOCS=OFF
         -DCMAKE_STATIC_BOOST=ON
         -DCMAKE_TESTING_ENABLED=ON
-        -DPY_VERSION=${{ matrix.py_version }}
+        -DPY_VERSION="${{ matrix.py_version }}"
 
     - name: Build
       # Build your program with the given configuration

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,6 +15,7 @@
         "-DCMAKE_SPHINX_DOCS=OFF",
         "-DCMAKE_STATIC_BOOST=OFF",
         "-DCMAKE_TESTING_ENABLED=ON",
+        "-DPY_VERSION=3.9"
     ],
     "files.associations": {
         "*.ipp": "cpp",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.19)
 
 #XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX#
 #XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX#
@@ -136,11 +136,18 @@ endfunction()
 #         "INCOMPATIBLE PYTHON VERSION, expected 3.6.x < 3.9.x but found - " 
 #         ${Python_VERSION})
 # endif()
-find_package(Python COMPONENTS Interpreter Development)
-if(${Python_VERSION} VERSION_LESS 3.6.0)
-  message(SEND_ERROR 
-    "UNTESTED PYTHON VERSION, expected >3.6.x but found - " ${Python_VERSION})
+if(NOT DEFINED PY_VERSION)
+  find_package(Python COMPONENTS Interpreter Development)
+else()
+  string(REPLACE "." ";" PY_VERSION_PART ${PY_VERSION})
+  LIST(GET PY_VERSION_PART 0 PY_VMAJOR)
+  LIST(GET PY_VERSION_PART 1 PY_VMINOR)
+  find_package(Python ${PY_VMAJOR}...<${PY_VMINOR} COMPONENTS Interpreter Development)
 endif()
+# if(${Python_VERSION} VERSION_LESS 3.6.0)
+#   message(SEND_ERROR 
+#     "UNTESTED PYTHON VERSION, expected >3.6.x but found - " ${Python_VERSION})
+# endif()
 
 message("The PYTHON_VERSION is ${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,20 +129,20 @@ endfunction()
 #---- SECTION 2.0 - External packages/libraries -----#
 #XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX#
 
-#---- Python3  ----#
-# find_package(Python3 3.7...<3.10  COMPONENTS Interpreter Development)
-# if(${Python3_VERSION} GREATER 3.9 OR ${Python3_VERSION} LESS 3.7)
+#---- Python  ----#
+# find_package(Python 3.7...<3.10  COMPONENTS Interpreter Development)
+# if(${Python_VERSION} GREATER 3.9 OR ${Python_VERSION} LESS 3.7)
 #     message(SEND_ERROR 
 #         "INCOMPATIBLE PYTHON VERSION, expected 3.7.x < 3.9.x but found - " 
-#         ${Python3_VERSION})
+#         ${Python_VERSION})
 # endif()
-find_package(Python3 COMPONENTS Interpreter Development)
-if(${Python3_VERSION} VERSION_LESS 3.7.0)
+find_package(Python COMPONENTS Interpreter Development)
+if(${Python_VERSION} VERSION_LESS 3.7.0)
   message(SEND_ERROR 
-    "UNTESTED PYTHON VERSION, expected >3.7.x but found - " ${Python3_VERSION})
+    "UNTESTED PYTHON VERSION, expected >3.7.x but found - " ${Python_VERSION})
 endif()
 
-message("The PYTHON_VERSION is ${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}")
+message("The PYTHON_VERSION is ${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}")
 
 #---- Pybind11  ----#
 # MUST BE CALLED AFTER FINDPYTHON: CMake 3.12+ (3.15+ recommended, 3.18.2+ ideal) 
@@ -156,7 +156,7 @@ set(pybind11_DIR ${PYBIND11_CMAKE_DIR})
 message(STATUS "PYBIND11 CMAKE_DIR PATH IS: ${PYBIND11_CMAKE_DIR}")
 message(STATUS "CMAKE_MODULE_PATH IS: ${CMAKE_MODULE_PATH}")
 
-set(PYBIND11_NOPYTHON ON)
+# set(PYBIND11_NOPYTHON ON)
 find_package(pybind11 REQUIRED)
 
 #---- Boost ----#
@@ -226,7 +226,7 @@ set(REL_PYPI_LAPKT_ROOT ${REL_PYPI_ROOT}/site_package/lapkt)
 
 #[[
 Note- When creating Python extensions, NEITHER the py extensions NOR the 
-lapkt libs need to be linked to Python3 shared libraries. Including the
+lapkt libs need to be linked to Python shared libraries. Including the
 headers is sufficient. The reference to Python symbols will be populated by
 when the library is loaded by the python interpreter. This would free the 
 python extensions from VERSION specific Python shared libs.
@@ -257,25 +257,25 @@ add_library(core SHARED)
 #---- Python extensions ----#
 
 #---- CXX Wrappers over LAPKT lib ----#
-# pybind11_add_module(wrapper SHARED)
-add_library(wrapper SHARED)
+pybind11_add_module(wrapper SHARED)
+# add_library(wrapper SHARED)
 set_target_properties(wrapper PROPERTIES
   PREFIX ""
   INSTALL_RPATH "${CMAKE_INSTALL_RPATH}:$ORIGIN"
 )
 
-target_include_directories(wrapper PRIVATE
-  ${Python3_INCLUDE_DIRS}
-)
+# target_include_directories(wrapper PRIVATE
+#   ${Python_INCLUDE_DIRS}
+# )
 
 target_link_libraries(wrapper PUBLIC
   core
-  pybind11::headers
+  # pybind11::headers
 )
 
 #---- Translate PDDL ----#
-# pybind11_add_module(pddl SHARED)
-add_library(pddl SHARED)
+pybind11_add_module(pddl SHARED)
+# add_library(pddl SHARED)
 set_target_properties(pddl PROPERTIES
   PREFIX ""
   INSTALL_RPATH "${CMAKE_INSTALL_RPATH}:$ORIGIN"
@@ -284,13 +284,13 @@ target_link_libraries(pddl PRIVATE
   core
   wrapper
 )
-target_include_directories(pddl PRIVATE
-  ${Python3_INCLUDE_DIRS}
-)
+# target_include_directories(pddl PRIVATE
+#   ${Python_INCLUDE_DIRS}
+# )
 
 #---- Planner ----#
-# pybind11_add_module(planner SHARED)
-add_library(planner SHARED)
+pybind11_add_module(planner SHARED)
+# add_library(planner SHARED)
 set_target_properties(planner PROPERTIES
   PREFIX ""
   INSTALL_RPATH "${CMAKE_INSTALL_RPATH}:$ORIGIN"
@@ -300,9 +300,9 @@ target_link_libraries(planner PRIVATE
   wrapper
   ${Boost_LIBRARIES}
 )
-target_include_directories(planner PRIVATE
-  ${Python3_INCLUDE_DIRS}
-)
+# target_include_directories(planner PRIVATE
+#   ${Python_INCLUDE_DIRS}
+# )
 
 #---- Add sub directories with source ----#
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,6 +156,7 @@ set(pybind11_DIR ${PYBIND11_CMAKE_DIR})
 message(STATUS "PYBIND11 CMAKE_DIR PATH IS: ${PYBIND11_CMAKE_DIR}")
 message(STATUS "CMAKE_MODULE_PATH IS: ${CMAKE_MODULE_PATH}")
 
+set(PYBIND11_NOPYTHON ON)
 find_package(pybind11 REQUIRED)
 
 #---- Boost ----#
@@ -256,17 +257,25 @@ add_library(core SHARED)
 #---- Python extensions ----#
 
 #---- CXX Wrappers over LAPKT lib ----#
-pybind11_add_module(wrapper SHARED)
+# pybind11_add_module(wrapper SHARED)
+add_library(wrapper SHARED)
 set_target_properties(wrapper PROPERTIES
   PREFIX ""
   INSTALL_RPATH "${CMAKE_INSTALL_RPATH}:$ORIGIN"
 )
+
+target_include_directories(wrapper PRIVATE
+  ${Python3_INCLUDE_DIRS}
+)
+
 target_link_libraries(wrapper PUBLIC
   core
+  pybind11::headers
 )
 
 #---- Translate PDDL ----#
-pybind11_add_module(pddl SHARED)
+# pybind11_add_module(pddl SHARED)
+add_library(pddl SHARED)
 set_target_properties(pddl PROPERTIES
   PREFIX ""
   INSTALL_RPATH "${CMAKE_INSTALL_RPATH}:$ORIGIN"
@@ -275,9 +284,13 @@ target_link_libraries(pddl PRIVATE
   core
   wrapper
 )
+target_include_directories(pddl PRIVATE
+  ${Python3_INCLUDE_DIRS}
+)
 
 #---- Planner ----#
-pybind11_add_module(planner SHARED)
+# pybind11_add_module(planner SHARED)
+add_library(planner SHARED)
 set_target_properties(planner PROPERTIES
   PREFIX ""
   INSTALL_RPATH "${CMAKE_INSTALL_RPATH}:$ORIGIN"
@@ -286,6 +299,9 @@ target_link_libraries(planner PRIVATE
   core
   wrapper
   ${Boost_LIBRARIES}
+)
+target_include_directories(planner PRIVATE
+  ${Python3_INCLUDE_DIRS}
 )
 
 #---- Add sub directories with source ----#

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,16 +130,16 @@ endfunction()
 #XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX#
 
 #---- Python  ----#
-# find_package(Python 3.7...<3.10  COMPONENTS Interpreter Development)
-# if(${Python_VERSION} GREATER 3.9 OR ${Python_VERSION} LESS 3.7)
+# find_package(Python 3.6...<3.11  COMPONENTS Interpreter Development)
+# if(${Python_VERSION} GREATER 3.10 OR ${Python_VERSION} LESS 3.6)
 #     message(SEND_ERROR 
-#         "INCOMPATIBLE PYTHON VERSION, expected 3.7.x < 3.9.x but found - " 
+#         "INCOMPATIBLE PYTHON VERSION, expected 3.6.x < 3.9.x but found - " 
 #         ${Python_VERSION})
 # endif()
 find_package(Python COMPONENTS Interpreter Development)
-if(${Python_VERSION} VERSION_LESS 3.7.0)
+if(${Python_VERSION} VERSION_LESS 3.6.0)
   message(SEND_ERROR 
-    "UNTESTED PYTHON VERSION, expected >3.7.x but found - " ${Python_VERSION})
+    "UNTESTED PYTHON VERSION, expected >3.6.x but found - " ${Python_VERSION})
 endif()
 
 message("The PYTHON_VERSION is ${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}")

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Developers who intend to build from source are required to **manually** install 
 
 **@Ubuntu**
 
-	python3 >= 3.7 <= 3.9
-	python3-dev >= 3.7 <= 3.9
+	python3 >= 3.6 <= 3.10
+	python3-dev >= 3.6 <= 3.10
 	cmake >= 3.16
 	gcc>=8
 	g++>=8

--- a/config/cmake/PostInstallScript.cmake
+++ b/config/cmake/PostInstallScript.cmake
@@ -1,9 +1,9 @@
 message("\n# x-x-x-x POST-INSTALL THINGS BEGIN HERE x-x-x-x #\n")
 
 find_package(Python3 COMPONENTS Interpreter Development)
-if(${Python3_VERSION} VERSION_LESS 3.7.0)
+if(${Python3_VERSION} VERSION_LESS 3.6.0)
     message(SEND_ERROR 
-        "INCOMPATIBLE PYTHON VERSION, expected >3.7.x but found - " 
+        "INCOMPATIBLE PYTHON VERSION, expected >3.6.x but found - " 
         ${Python3_VERSION})
 endif()
 

--- a/config/cmake/SuperBuildLinux/CMakeLists.txt
+++ b/config/cmake/SuperBuildLinux/CMakeLists.txt
@@ -4,7 +4,6 @@
 #----SECTION 1.1 -Install python prerequisites ----#
 
 # Fetch Python Exec
-find_package(Python3 COMPONENTS Interpreter Development)
 if(NOT DEFINED PY_VERSION)
   find_package(Python COMPONENTS Interpreter Development)
 else()

--- a/config/cmake/SuperBuildLinux/CMakeLists.txt
+++ b/config/cmake/SuperBuildLinux/CMakeLists.txt
@@ -14,22 +14,22 @@ else()
   find_package(Python ${PY_VMAJOR}.${PY_VMINOR}...<${PY_VMAJOR}.${PY_VMINOR_NEXT} 
     COMPONENTS Interpreter Development)
 endif()
-# if(${Python3_VERSION} VERSION_LESS 3.6.0)
+# if(${Python_VERSION} VERSION_LESS 3.6.0)
 #   message(SEND_ERROR
 #     "INCOMPATIBLE PYTHON VERSION, expected >3.6.x but found - "
-#     ${Python3_VERSION})
+#     ${Python_VERSION})
 # endif()
-message("The PYTHON_VERSION is ${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}")
+message("The PYTHON_VERSION is ${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}")
 
 # Install pip requirements
-execute_process(COMMAND ${Python3_EXECUTABLE} -m pip install
+execute_process(COMMAND ${Python_EXECUTABLE} -m pip install
   -r ${PROJECT_SOURCE_DIR}/config/pre_build/pip_requirements.txt
   RESULT_VARIABLE out
 )
 message(STATUS "Python result: ${out}")
 
 #Fetch path to Pybind11
-execute_process(COMMAND ${Python3_EXECUTABLE} -m pybind11 --cmakedir 
+execute_process(COMMAND ${Python_EXECUTABLE} -m pybind11 --cmakedir 
   OUTPUT_VARIABLE PYBIND11_CMAKE_DIR
   ERROR_VARIABLE PYBIND11_CMAKE_DIR_ERROR
   OUTPUT_STRIP_TRAILING_WHITESPACE
@@ -160,10 +160,10 @@ else()
   set(BOOST_VARIANT "release")
 endif()
 message("Building Boost in " ${BOOST_VARIANT} " mode")
-file(WRITE ${DEPS_BUILD_DIR}/boost/user-config.jam "using python  :  ${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR} ;")
+file(WRITE ${DEPS_BUILD_DIR}/boost/user-config.jam "using python  :  ${Python_VERSION_MAJOR}.${Python_VERSION_MINOR} ;")
 
 # LOGS
-message("Boost is built using python  :  ${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR} ;")
+message("Boost is built using python  :  ${Python_VERSION_MAJOR}.${Python_VERSION_MINOR} ;")
 message("The boost build command is : ./b2 --user-config=${PROJECT_BINARY_DIR}/../build_external/boost/user-config.jam --with-python --with-program_options --build-dir=${PROJECT_BINARY_DIR}/../build_external/boost/build variant=${BOOST_VARIANT} optimization=space link=static install cxxflags=-fpic")
 
 

--- a/config/cmake/SuperBuildLinux/CMakeLists.txt
+++ b/config/cmake/SuperBuildLinux/CMakeLists.txt
@@ -5,9 +5,9 @@
 
 # Fetch Python Exec
 find_package(Python3 COMPONENTS Interpreter Development)
-if(${Python3_VERSION} VERSION_LESS 3.7.0)
+if(${Python3_VERSION} VERSION_LESS 3.6.0)
   message(SEND_ERROR
-    "INCOMPATIBLE PYTHON VERSION, expected >3.7.x but found - "
+    "INCOMPATIBLE PYTHON VERSION, expected >3.6.x but found - "
     ${Python3_VERSION})
 endif()
 message("The PYTHON_VERSION is ${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}")

--- a/config/cmake/SuperBuildLinux/CMakeLists.txt
+++ b/config/cmake/SuperBuildLinux/CMakeLists.txt
@@ -5,11 +5,21 @@
 
 # Fetch Python Exec
 find_package(Python3 COMPONENTS Interpreter Development)
-if(${Python3_VERSION} VERSION_LESS 3.6.0)
-  message(SEND_ERROR
-    "INCOMPATIBLE PYTHON VERSION, expected >3.6.x but found - "
-    ${Python3_VERSION})
+if(NOT DEFINED PY_VERSION)
+  find_package(Python COMPONENTS Interpreter Development)
+else()
+  string(REPLACE "." ";" PY_VERSION_PART ${PY_VERSION})
+  LIST(GET PY_VERSION_PART 0 PY_VMAJOR)
+  LIST(GET PY_VERSION_PART 1 PY_VMINOR)
+  MATH(EXPR PY_VMINOR_NEXT "${PY_VMINOR} + 1")
+  find_package(Python ${PY_VMAJOR}.${PY_VMINOR}...<${PY_VMAJOR}.${PY_VMINOR_NEXT} 
+    COMPONENTS Interpreter Development)
 endif()
+# if(${Python3_VERSION} VERSION_LESS 3.6.0)
+#   message(SEND_ERROR
+#     "INCOMPATIBLE PYTHON VERSION, expected >3.6.x but found - "
+#     ${Python3_VERSION})
+# endif()
 message("The PYTHON_VERSION is ${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}")
 
 # Install pip requirements

--- a/delete/install.py
+++ b/delete/install.py
@@ -49,7 +49,7 @@ def exists_python_module(name) :
         return False
 
 if __name__ == '__main__' :
-    assert version_info >= (3,7,0), 'Python >= 3.7 required'
+    assert version_info >= (3,7,0), 'Python >= 3.6 required'
 
     parser  =   ArgumentParser(description="Take LAPKT installation options")    
     parser.add_argument('--cmake', action='store', nargs='?',

--- a/src/python/_package/setup.py
+++ b/src/python/_package/setup.py
@@ -29,7 +29,7 @@ setup(
         "Operating System :: POSIX :: Linux",
         "Operating System :: MacOS"
         ],
-    python_requires='>=3.7',
+    python_requires='>=3.6',
     install_requires=[
         'tarski-lapkt[gringo]',  # PLACEHOLDER until tarski's next major update
         # 'tarski',

--- a/src/python/_package/setup.py
+++ b/src/python/_package/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="lapkt",
-    version="0.0.1",
+    version="0.0.2",
     author="Anubhav Singh, Nir Lipovetzky, "
             + "Miquel Ramirez, Christian Muise",
     author_email="anubhav.singh.er@pm.me, nirlipo@gmail.com, "

--- a/src/translate/pddl/CMakeLists.txt
+++ b/src/translate/pddl/CMakeLists.txt
@@ -1,5 +1,5 @@
 # #
-# target_include_directories(lapkt PRIVATE ${Python3_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} )
+# target_include_directories(lapkt PRIVATE ${Python_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} )
 # target_link_libraries( lapkt PRIVATE
 #     lapkt 
 #     ${Boost_LIBRARIES}


### PR DESCRIPTION
A pybind11 extension can't be compiled with headers only on windows and mac, we have to link with python libraries too. If we don't do that, the linker throws missing symbol error. As of now, I am not sure if there is a workaround. Looking at the pybind11 issues, there aren't. Hence, I build package wheels for Python v[3.6, 3.7, 3.8, 3.9, 3.10] through github actions separately.