### PR TITLE
Update novelty.hxx

### DIFF
--- a/src/node_eval/novelty/novelty.hxx
+++ b/src/node_eval/novelty/novelty.hxx
@@ -236,7 +236,8 @@ protected:
 					} else {
 
 						// If all elements in the tuple are equal, ignore the tuple
-						if (std::any_of(tuple.cbegin(), tuple.cend(), [&tuple](unsigned x){ return x != tuple[0]; }  )) continue;
+						if (std::all_of(tuple.cbegin(), tuple.cend(), [&tuple](unsigned x){ return x == tuple[0]; })) continue;
+						
 						/**
 						 * get tuples from indexes
 						 */
@@ -340,7 +341,7 @@ protected:
 			} else {
 
 				// If all elements in the tuple are equal, ignore the tuple
-				if (std::any_of(tuple.cbegin(), tuple.cend(), [&tuple](unsigned x){ return x != tuple[0]; }  )) continue;
+				if (std::all_of(tuple.cbegin(), tuple.cend(), [&tuple](unsigned x){ return x == tuple[0]; })) continue;
 				tuple_idx = tuple2idx( tuple, arity );
 			}
 


### PR DESCRIPTION
When using novelty.hxx, i.e. the IW planner it won't work for width larger than 2 since it skips all nodes then. 

Instead of skipping the node if all fluents are the same, it did the opposite and skipped if anyone is not the same.

Weirdly