### PR TITLE
Small bugfix novelty.hxx

### DIFF
--- a/interfaces/agnostic/novelty.hxx
+++ b/interfaces/agnostic/novelty.hxx
@@ -224,7 +224,7 @@ protected:
 					} else {
 
 						// If all elements in the tuple are equal, ignore the tuple
-						if (std::any_of(tuple.cbegin(), tuple.cend(), [&tuple](unsigned x){ return x != tuple[0]; }  )) continue;
+						if (std::all_of(tuple.cbegin(), tuple.cend(), [&tuple](unsigned x){ return x == tuple[0]; })) continue;
 						/**
 						 * get tuples from indexes
 						 */
@@ -328,7 +328,7 @@ protected:
 			} else {
 				
 				// If all elements in the tuple are equal, ignore the tuple
-				if (std::any_of(tuple.cbegin(), tuple.cend(), [&tuple](unsigned x){ return x != tuple[0]; }  )) continue;
+				if (std::all_of(tuple.cbegin(), tuple.cend(), [&tuple](unsigned x){ return x == tuple[0]; })) continue;
 				tuple_idx = tuple2idx( tuple, arity );
 			}
 			


### PR DESCRIPTION
Same issue  as with the Devel2.0, the code before skipped the nodes (width larger 2) if any of its fluent is different. This is the case for any novel (and most non novel) tuple. Therefore it is changed to skip if all are equal only